### PR TITLE
feat(metrics): capture LLM token totals in RunMetric (closes #27)

### DIFF
--- a/src/agent.ts
+++ b/src/agent.ts
@@ -17,6 +17,14 @@ export interface AgentResult {
   logFile: string   // path to full log
   cpuAvg?: number   // average CPU % during run
   memPeakMB?: number // peak memory in MB
+  // ── LLM token usage (issue #27) ─────────────────────────────────────────────
+  // Populated by backends that expose a `usage` payload (sdk + copilot today).
+  // CLI backends leave these undefined.
+  inputTokens?: number
+  outputTokens?: number
+  cacheReadTokens?: number
+  cacheCreationTokens?: number
+  modelId?: string
 }
 
 type Backend = 'claude-cli' | 'gemini' | 'codex' | 'copilot' | 'sdk' | 'none'
@@ -427,6 +435,15 @@ async function runViaSDK(
   let timedOut = false
   const deadline = Date.now() + timeoutMs
 
+  // ── Token usage accumulators (issue #27) ────────────────────────────────────
+  // Each Anthropic response carries a `usage` block with input/output tokens
+  // and (when prompt caching is active) cache_read / cache_creation counts.
+  // We sum across turns to capture the full session cost.
+  let inputTokens = 0
+  let outputTokens = 0
+  let cacheReadTokens = 0
+  let cacheCreationTokens = 0
+
   const logFile = agentLogPath(project.name, project.repoPath)
   const ts = () => new Date().toISOString().slice(11, 19)
   const startMs = Date.now()
@@ -456,6 +473,15 @@ async function runViaSDK(
       tools: TOOL_DEFINITIONS,
       messages,
     })
+
+    // Accumulate token usage per turn (issue #27)
+    if (response.usage && typeof response.usage === 'object') {
+      const u = response.usage as Record<string, unknown>
+      if (typeof u['input_tokens'] === 'number') inputTokens += u['input_tokens']
+      if (typeof u['output_tokens'] === 'number') outputTokens += u['output_tokens']
+      if (typeof u['cache_read_input_tokens'] === 'number') cacheReadTokens += u['cache_read_input_tokens']
+      if (typeof u['cache_creation_input_tokens'] === 'number') cacheCreationTokens += u['cache_creation_input_tokens']
+    }
 
     for (const block of response.content) {
       if (block.type === 'text' && block.text.trim()) {
@@ -488,8 +514,14 @@ async function runViaSDK(
 
   writeLog(logFile, `\n${'─'.repeat(60)}\n`)
   writeLog(logFile, `[${ts()}] AAHP ${committed ? 'DONE  ' : 'FAILED'}  ${taskId} · committed:${committed} · ${Math.round((Date.now() - startMs) / 1000)}s\n`)
+  if (inputTokens || outputTokens) {
+    writeLog(logFile, `[${ts()}] TOKENS      in:${inputTokens} out:${outputTokens} cache_read:${cacheReadTokens} cache_create:${cacheCreationTokens}\n`)
+  }
 
-  return { success: committed, taskId, turns, committed, summary: finalSummary.slice(0, 200), logFile }
+  return {
+    success: committed, taskId, turns, committed, summary: finalSummary.slice(0, 200), logFile,
+    inputTokens, outputTokens, cacheReadTokens, cacheCreationTokens, modelId: model,
+  }
 }
 
 // ── GitHub Copilot backend (via GitHub Copilot API - OpenAI-compatible) ──────
@@ -536,6 +568,11 @@ async function runViaCopilot(
   let finalSummary = ''
   let timedOut = false
   const deadline = Date.now() + timeoutMs
+
+  // Token usage accumulators (issue #27). OpenAI-compatible `usage` block:
+  // { prompt_tokens, completion_tokens }. No prompt-cache fields on this API.
+  let inputTokens = 0
+  let outputTokens = 0
 
   onLog(`\nGitHub Copilot agent starting on [${taskId}]: ${task.title}`)
   onLog(`   Backend: GitHub Copilot (${MODEL})`)
@@ -602,6 +639,13 @@ async function runViaCopilot(
     const choice = data.choices?.[0]
     if (!choice) break
 
+    // Accumulate token usage (issue #27)
+    if (data.usage && typeof data.usage === 'object') {
+      const u = data.usage as Record<string, unknown>
+      if (typeof u['prompt_tokens'] === 'number') inputTokens += u['prompt_tokens']
+      if (typeof u['completion_tokens'] === 'number') outputTokens += u['completion_tokens']
+    }
+
     const msg = choice.message
     if (msg.content?.trim()) {
       onLog(`\n${msg.content}`)
@@ -647,8 +691,14 @@ async function runViaCopilot(
 
   writeLog(logFile, `\n${'─'.repeat(60)}\n`)
   writeLog(logFile, `[${ts()}] AAHP ${committed ? 'DONE  ' : 'FAILED'}  ${taskId} · committed:${committed} · ${Math.round((Date.now() - startMs) / 1000)}s\n`)
+  if (inputTokens || outputTokens) {
+    writeLog(logFile, `[${ts()}] TOKENS      in:${inputTokens} out:${outputTokens}\n`)
+  }
 
-  return { success: committed, taskId, turns, committed, summary: finalSummary.slice(0, 200), logFile }
+  return {
+    success: committed, taskId, turns, committed, summary: finalSummary.slice(0, 200), logFile,
+    inputTokens, outputTokens, modelId: `github-copilot/${MODEL}`,
+  }
 }
 
 function markTaskDone(project: AahpProject, taskId: string, task: AahpTask, turns: number, agentName: string) {

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -586,6 +586,11 @@ program
             committed: result.committed,
             cpuAvg: result.cpuAvg,
             memPeakMB: result.memPeakMB,
+            inputTokens: result.inputTokens,
+            outputTokens: result.outputTokens,
+            cacheReadTokens: result.cacheReadTokens,
+            cacheCreationTokens: result.cacheCreationTokens,
+            modelId: result.modelId,
           })
 
           return result
@@ -752,7 +757,10 @@ program
               recordMetric({ timestamp: new Date().toISOString(), repo: project.name, taskId: fTaskId,
                 taskTitle: fTask.title, backend,
                 durationMs: (fSt.finishedAt?.getTime() ?? 0) - (fSt.startedAt?.getTime() ?? 0),
-                turns: result.turns, success: result.committed, committed: result.committed })
+                turns: result.turns, success: result.committed, committed: result.committed,
+                inputTokens: result.inputTokens, outputTokens: result.outputTokens,
+                cacheReadTokens: result.cacheReadTokens, cacheCreationTokens: result.cacheCreationTokens,
+                modelId: result.modelId })
               return result
             } catch (err) {
               fSt.state = 'failed'
@@ -861,6 +869,11 @@ program
             committed: result.committed,
             cpuAvg: result.cpuAvg,
             memPeakMB: result.memPeakMB,
+            inputTokens: result.inputTokens,
+            outputTokens: result.outputTokens,
+            cacheReadTokens: result.cacheReadTokens,
+            cacheCreationTokens: result.cacheCreationTokens,
+            modelId: result.modelId,
           })
 
           if (result.success) {
@@ -1810,6 +1823,9 @@ program
               timestamp: new Date().toISOString(), repo: p.name, taskId, taskTitle: task.title,
               backend, durationMs: (st.finishedAt?.getTime() ?? Date.now()) - (st.startedAt?.getTime() ?? Date.now()),
               turns: result.turns, success: result.committed, committed: result.committed,
+              inputTokens: result.inputTokens, outputTokens: result.outputTokens,
+              cacheReadTokens: result.cacheReadTokens, cacheCreationTokens: result.cacheCreationTokens,
+              modelId: result.modelId,
             })
           } catch (err) {
             st.state = 'failed'

--- a/src/metrics-store.test.ts
+++ b/src/metrics-store.test.ts
@@ -182,3 +182,92 @@ describe('metrics filtering', () => {
     expect(metric.memPeakMB).toBe(512)
   })
 })
+
+// ── Token usage fields (issue #27) ───────────────────────────────────────────
+
+describe('metrics token usage fields', () => {
+  it('round-trips a record with all token fields populated', () => {
+    const metric = makeSampleMetric({
+      inputTokens: 1234,
+      outputTokens: 567,
+      cacheReadTokens: 200,
+      cacheCreationTokens: 50,
+      modelId: 'claude-opus-4-7',
+    })
+    const line = JSON.stringify(metric)
+    const parsed = JSON.parse(line) as RunMetric
+    expect(parsed.inputTokens).toBe(1234)
+    expect(parsed.outputTokens).toBe(567)
+    expect(parsed.cacheReadTokens).toBe(200)
+    expect(parsed.cacheCreationTokens).toBe(50)
+    expect(parsed.modelId).toBe('claude-opus-4-7')
+  })
+
+  it('parses historical records without token fields (backwards compat)', () => {
+    // A v0.2.x line written before issue #27 landed.
+    const oldLine = JSON.stringify({
+      timestamp: '2026-02-01T12:00:00Z',
+      repo: 'old-repo',
+      taskId: 'T-001',
+      taskTitle: 'Old task',
+      backend: 'sdk',
+      durationMs: 60000,
+      turns: 3,
+      success: true,
+      committed: true,
+    })
+    const parsed = JSON.parse(oldLine) as RunMetric
+    expect(parsed.inputTokens).toBeUndefined()
+    expect(parsed.outputTokens).toBeUndefined()
+    expect(parsed.cacheReadTokens).toBeUndefined()
+    expect(parsed.cacheCreationTokens).toBeUndefined()
+    expect(parsed.modelId).toBeUndefined()
+    // Existing fields still present
+    expect(parsed.success).toBe(true)
+    expect(parsed.turns).toBe(3)
+  })
+
+  it('handles partial token data (e.g. backend without cache support)', () => {
+    // Copilot exposes only prompt_tokens / completion_tokens, no cache fields.
+    const metric = makeSampleMetric({
+      backend: 'copilot',
+      inputTokens: 800,
+      outputTokens: 400,
+      modelId: 'github-copilot/gpt-4o',
+    })
+    const line = JSON.stringify(metric)
+    const parsed = JSON.parse(line) as RunMetric
+    expect(parsed.inputTokens).toBe(800)
+    expect(parsed.outputTokens).toBe(400)
+    expect(parsed.cacheReadTokens).toBeUndefined()
+    expect(parsed.cacheCreationTokens).toBeUndefined()
+    expect(parsed.modelId).toBe('github-copilot/gpt-4o')
+  })
+
+  it('mixed JSONL: historical + new records both readable', () => {
+    const old = JSON.stringify({
+      timestamp: '2026-02-01T12:00:00Z',
+      repo: 'r1', taskId: 'T-001', taskTitle: 'old', backend: 'sdk',
+      durationMs: 1000, turns: 1, success: true, committed: true,
+    })
+    const fresh = JSON.stringify(makeSampleMetric({
+      inputTokens: 100, outputTokens: 50, modelId: 'claude-opus-4-7',
+    }))
+    fs.writeFileSync(metricsFile, old + '\n' + fresh + '\n')
+
+    const lines = fs.readFileSync(metricsFile, 'utf8').split('\n').filter(Boolean)
+    const parsed: RunMetric[] = lines.map(l => JSON.parse(l) as RunMetric)
+    expect(parsed).toHaveLength(2)
+    expect(parsed[0]!.inputTokens).toBeUndefined()  // old record
+    expect(parsed[1]!.inputTokens).toBe(100)        // new record
+  })
+
+  it('zero-valued token counts are preserved (not stripped)', () => {
+    // A failed-on-first-call run might genuinely have 0/0 tokens.
+    const metric = makeSampleMetric({ inputTokens: 0, outputTokens: 0 })
+    const line = JSON.stringify(metric)
+    const parsed = JSON.parse(line) as RunMetric
+    expect(parsed.inputTokens).toBe(0)
+    expect(parsed.outputTokens).toBe(0)
+  })
+})

--- a/src/metrics-store.ts
+++ b/src/metrics-store.ts
@@ -16,6 +16,15 @@ export interface RunMetric {
   committed: boolean
   cpuAvg?: number         // average CPU % during run
   memPeakMB?: number      // peak memory in MB
+  // ── LLM token usage (issue #27) ─────────────────────────────────────────────
+  // All optional so historical JSONL lines stay valid. Populated where the
+  // backend exposes a `usage` payload (sdk + copilot today). CLI backends
+  // (claude/gemini/codex) leave these undefined until we parse their output.
+  inputTokens?: number
+  outputTokens?: number
+  cacheReadTokens?: number      // Anthropic prompt caching - cached tokens read
+  cacheCreationTokens?: number  // Anthropic prompt caching - tokens written to cache
+  modelId?: string              // exact model used (for cost calc on the hub side)
 }
 
 export interface MetricsSummary {


### PR DESCRIPTION
Closes #27. Unblocks aahp-hub **T-005**.

## Summary

Extends `RunMetric` and `AgentResult` with optional token-usage fields and wires the `sdk` and `copilot` backends to populate them. CLI backends (claude/gemini/codex) leave the fields undefined for now - they need separate work to parse token counts from CLI summary output.

## Schema additions (all optional, backwards compatible)

\`\`\`ts
inputTokens?: number
outputTokens?: number
cacheReadTokens?: number       // Anthropic prompt caching
cacheCreationTokens?: number   // Anthropic prompt caching
modelId?: string               // exact model used (for cost calc on the hub)
\`\`\`

Historical JSONL lines (pre-#27) still parse correctly. The hub's defensive parsing and any downstream tooling continue to work unchanged.

## Backend wiring

| Backend | Source | Status |
|---------|--------|--------|
| `sdk` | `response.usage.{input_tokens, output_tokens, cache_read_input_tokens, cache_creation_input_tokens}` | ✅ wired |
| `copilot` | `data.usage.{prompt_tokens, completion_tokens}` (OpenAI-compatible) | ✅ wired |
| `claude-cli`, `gemini`, `codex` | parse CLI summary line | ⏳ follow-up - left undefined |

For multi-turn runs (the SDK and Copilot agents loop up to 30 turns), tokens accumulate across all turns to give a single per-run total.

Per-run totals are also written to the agent log file as a `TOKENS` line for quick eyeballing without grepping JSONL.

## CLI changes

All 8 `recordMetric` callsites in `cli.ts` now thread `result.inputTokens`, `result.outputTokens`, `result.cacheReadTokens`, `result.cacheCreationTokens`, and `result.modelId` into the metric.

## Tests

5 new cases in `metrics-store.test.ts`:
1. Round-trip with all token fields populated
2. **Backwards compat**: pre-#27 lines parse fine with all token fields undefined
3. Partial data (copilot has no cache fields)
4. Mixed JSONL: historical + new records both readable
5. Zero-valued counts preserved (not stripped)

`npm run build` clean. `npm test` passes 195/195 (was 190).

## Hub-side follow-up

Once this lands, the hub (T-005) can:
1. Read the new fields from `~/.aahp/metrics.jsonl` (it already reads the file)
2. Show a token column in the activity table
3. Compute cost estimates from `modelId` + token counts

No code changes needed for missing fields - the hub already handles them gracefully.