### PR TITLE
feat(control): add /abort endpoint for running agents (closes #28)

### DIFF
--- a/src/agent.ts
+++ b/src/agent.ts
@@ -17,6 +17,10 @@ export interface AgentResult {
   logFile: string   // path to full log
   cpuAvg?: number   // average CPU % during run
   memPeakMB?: number // peak memory in MB
+  // ── Abort marker (issue #28) ────────────────────────────────────────────────
+  // Set to true when the run was terminated by a POST /abort from the hub.
+  // Implies success=false; allows recordMetric to distinguish abort from failure.
+  aborted?: boolean
 }
 
 type Backend = 'claude-cli' | 'gemini' | 'codex' | 'copilot' | 'sdk' | 'none'
@@ -126,7 +130,8 @@ async function runViaClaudeCLI(
   taskId: string,
   task: AahpTask,
   onLog: (msg: string) => void,
-  timeoutMs: number = 10 * 60 * 1000
+  timeoutMs: number = 10 * 60 * 1000,
+  abortSignal?: AbortSignal
 ): Promise<AgentResult> {
   const systemPrompt = buildSystemPrompt(project, taskId, task)
   const userPrompt = `${systemPrompt}\n\n---\n\nStart working on [${taskId}]: ${task.title}\n\nRead relevant files first, then implement, test, and commit. Mark the task done in MANIFEST.json when finished.`
@@ -149,6 +154,7 @@ async function runViaClaudeCLI(
 
   let output = ''
   let exitCode: number | null = null
+  let aborted = false
 
   const CLAUDE_TIMEOUT_MS = timeoutMs
   const claudeCmd = process.platform === 'win32' ? 'claude.cmd' : 'claude'
@@ -184,6 +190,18 @@ async function runViaClaudeCLI(
       setTimeout(() => { try { proc.kill('SIGKILL') } catch {} }, 5000)
     }, CLAUDE_TIMEOUT_MS)
 
+    // External abort hook (issue #28) - SIGTERM then SIGKILL after 5s
+    const abortHandler = () => {
+      aborted = true
+      onLog(`\nClaude CLI aborted by control endpoint - sending SIGTERM`)
+      try { proc.kill('SIGTERM') } catch { /* already exited */ }
+      setTimeout(() => { try { proc.kill('SIGKILL') } catch {} }, 5000)
+    }
+    if (abortSignal) {
+      if (abortSignal.aborted) abortHandler()
+      else abortSignal.addEventListener('abort', abortHandler, { once: true })
+    }
+
     proc.stdin.write(userPrompt)
     proc.stdin.end()
 
@@ -202,13 +220,15 @@ async function runViaClaudeCLI(
 
     proc.on('close', (code) => {
       clearTimeout(timer)
+      if (abortSignal) abortSignal.removeEventListener('abort', abortHandler)
       resMonitor?.stop()
       exitCode = code
-      if (code !== 0) onLog(`Claude CLI exited with code ${code}`)
+      if (code !== 0 && !aborted) onLog(`Claude CLI exited with code ${code}`)
       resolve()
     })
     proc.on('error', (err) => {
       clearTimeout(timer)
+      if (abortSignal) abortSignal.removeEventListener('abort', abortHandler)
       resMonitor?.stop()
       onLog(`\nspawn error: ${err.message}`)
       resolve()
@@ -230,15 +250,16 @@ async function runViaClaudeCLI(
       output.toLowerCase().includes('[master ')
   }
 
-  if (committed) {
+  if (committed && !aborted) {
     markTaskDone(project, taskId, task, 1, 'claude-code')
     onLog(`\nMANIFEST.json updated - [${taskId}] marked done`)
   }
 
-  writeLog(logFile, `[${ts()}] AAHP ${committed ? 'DONE  ' : 'FAILED'}  ${taskId} · committed:${committed} · ${Math.round((Date.now() - startMs) / 1000)}s\n`)
+  const cliStatus = aborted ? 'ABORT ' : (committed ? 'DONE  ' : 'FAILED')
+  writeLog(logFile, `[${ts()}] AAHP ${cliStatus}  ${taskId} · committed:${committed} · ${Math.round((Date.now() - startMs) / 1000)}s\n`)
 
   return {
-    success: committed,
+    success: committed && !aborted,
     taskId,
     turns: 1,
     committed,
@@ -246,6 +267,7 @@ async function runViaClaudeCLI(
     logFile,
     cpuAvg: resMonitor?.avgCpu(),
     memPeakMB: resMonitor?.peakMemMB(),
+    aborted: aborted || undefined,
   }
 }
 
@@ -262,7 +284,8 @@ async function runViaCLI(
   task: AahpTask,
   agentLabel: string,
   onLog: (msg: string) => void,
-  timeoutMs: number
+  timeoutMs: number,
+  abortSignal?: AbortSignal
 ): Promise<AgentResult> {
   const systemPrompt = buildSystemPrompt(project, taskId, task)
   const userPrompt = `${systemPrompt}\n\n---\n\nStart working on [${taskId}]: ${task.title}\n\nRead relevant files first, then implement, test, and commit. Mark the task done in MANIFEST.json when finished.`
@@ -285,6 +308,7 @@ async function runViaCLI(
   let output = ''
   let exitCode: number | null = null
   let resMonitor: ResourceMonitor | undefined
+  let aborted = false
 
   await new Promise<void>((resolve) => {
     const proc = spawn(cliName, cliArgs, {
@@ -304,6 +328,18 @@ async function runViaCLI(
       setTimeout(() => { try { proc.kill('SIGKILL') } catch {} }, 5000)
     }, timeoutMs)
 
+    // External abort hook (issue #28) - SIGTERM then SIGKILL after 5s
+    const abortHandler = () => {
+      aborted = true
+      onLog(`\n${cliName} aborted by control endpoint - sending SIGTERM`)
+      try { proc.kill('SIGTERM') } catch { /* already exited */ }
+      setTimeout(() => { try { proc.kill('SIGKILL') } catch {} }, 5000)
+    }
+    if (abortSignal) {
+      if (abortSignal.aborted) abortHandler()
+      else abortSignal.addEventListener('abort', abortHandler, { once: true })
+    }
+
     proc.stdin.write(userPrompt)
     proc.stdin.end()
 
@@ -319,13 +355,15 @@ async function runViaCLI(
     })
     proc.on('close', (code) => {
       clearTimeout(timer)
+      if (abortSignal) abortSignal.removeEventListener('abort', abortHandler)
       resMonitor?.stop()
       exitCode = code
-      if (code !== 0) onLog(`\n${cliName} exited with code ${code}`)
+      if (code !== 0 && !aborted) onLog(`\n${cliName} exited with code ${code}`)
       resolve()
     })
     proc.on('error', (err) => {
       clearTimeout(timer)
+      if (abortSignal) abortSignal.removeEventListener('abort', abortHandler)
       resMonitor?.stop()
       onLog(`\nspawn error: ${err.message}`)
       resolve()
@@ -345,15 +383,16 @@ async function runViaCLI(
       output.toLowerCase().includes('[master ')
   }
 
-  if (committed) {
+  if (committed && !aborted) {
     markTaskDone(project, taskId, task, 1, agentLabel)
     onLog(`\nMANIFEST.json updated - [${taskId}] marked done`)
   }
 
-  writeLog(logFile, `[${ts()}] AAHP ${committed ? 'DONE  ' : 'FAILED'}  ${taskId} · committed:${committed} · ${Math.round((Date.now() - startMs) / 1000)}s\n`)
+  const cliRunStatus = aborted ? 'ABORT ' : (committed ? 'DONE  ' : 'FAILED')
+  writeLog(logFile, `[${ts()}] AAHP ${cliRunStatus}  ${taskId} · committed:${committed} · ${Math.round((Date.now() - startMs) / 1000)}s\n`)
 
   return {
-    success: committed,
+    success: committed && !aborted,
     taskId,
     turns: 1,
     committed,
@@ -361,6 +400,7 @@ async function runViaCLI(
     logFile,
     cpuAvg: resMonitor?.avgCpu(),
     memPeakMB: resMonitor?.peakMemMB(),
+    aborted: aborted || undefined,
   }
 }
 
@@ -375,11 +415,12 @@ async function runViaGeminiCLI(
   task: AahpTask,
   onLog: (msg: string) => void,
   timeoutMs: number = 10 * 60 * 1000,
-  model: string = 'gemini-3.1-pro'
+  model: string = 'gemini-3.1-pro',
+  abortSignal?: AbortSignal
 ): Promise<AgentResult> {
   // -p "" triggers headless mode; actual prompt arrives on stdin
   const args = ['-m', model, '-p', '', '--approval-mode', 'yolo']
-  return runViaCLI('gemini', args, project, taskId, task, `Gemini/${model}`, onLog, timeoutMs)
+  return runViaCLI('gemini', args, project, taskId, task, `Gemini/${model}`, onLog, timeoutMs, abortSignal)
 }
 
 /**
@@ -392,10 +433,11 @@ async function runViaCodexCLI(
   task: AahpTask,
   onLog: (msg: string) => void,
   timeoutMs: number = 10 * 60 * 1000,
-  model: string = 'gpt-5.5'
+  model: string = 'gpt-5.5',
+  abortSignal?: AbortSignal
 ): Promise<AgentResult> {
   const args = ['exec', '--model', model, '--full-auto']
-  return runViaCLI('codex', args, project, taskId, task, `Codex/${model}`, onLog, timeoutMs)
+  return runViaCLI('codex', args, project, taskId, task, `Codex/${model}`, onLog, timeoutMs, abortSignal)
 }
 
 /** Run agent via Anthropic SDK(direct API key) - fallback if claude CLI not available */
@@ -406,7 +448,8 @@ async function runViaSDK(
   apiKey: string,
   onLog: (msg: string) => void,
   timeoutMs: number = 10 * 60 * 1000,
-  model: string = 'claude-opus-4-7'
+  model: string = 'claude-opus-4-7',
+  abortSignal?: AbortSignal
 ): Promise<AgentResult> {
   const { default: Anthropic } = await import('@anthropic-ai/sdk')
 
@@ -425,6 +468,7 @@ async function runViaSDK(
   let committed = false
   let finalSummary = ''
   let timedOut = false
+  let aborted = false
   const deadline = Date.now() + timeoutMs
 
   const logFile = agentLogPath(project.name, project.repoPath)
@@ -445,17 +489,32 @@ async function runViaSDK(
       timedOut = true
       break
     }
+    if (abortSignal?.aborted) {
+      onLog(`\nSDK agent aborted by control endpoint`)
+      aborted = true
+      break
+    }
 
     turns++
     onLog(`\n-- Turn ${turns}/${MAX_TURNS} --`)
 
-    const response = await (client.messages as any).create({
-      model,
-      max_tokens: 8192,
-      system: systemPrompt,
-      tools: TOOL_DEFINITIONS,
-      messages,
-    })
+    let response: any
+    try {
+      response = await (client.messages as any).create({
+        model,
+        max_tokens: 8192,
+        system: systemPrompt,
+        tools: TOOL_DEFINITIONS,
+        messages,
+      }, abortSignal ? { signal: abortSignal } : undefined)
+    } catch (err) {
+      if (abortSignal?.aborted) {
+        onLog(`\nSDK agent aborted by control endpoint`)
+        aborted = true
+        break
+      }
+      throw err
+    }
 
     for (const block of response.content) {
       if (block.type === 'text' && block.text.trim()) {
@@ -487,9 +546,14 @@ async function runViaSDK(
   if (timedOut) onLog(`\nAgent was stopped due to timeout after ${turns} turns`)
 
   writeLog(logFile, `\n${'─'.repeat(60)}\n`)
-  writeLog(logFile, `[${ts()}] AAHP ${committed ? 'DONE  ' : 'FAILED'}  ${taskId} · committed:${committed} · ${Math.round((Date.now() - startMs) / 1000)}s\n`)
+  const sdkStatus = aborted ? 'ABORT ' : (committed ? 'DONE  ' : 'FAILED')
+  writeLog(logFile, `[${ts()}] AAHP ${sdkStatus}  ${taskId} · committed:${committed} · ${Math.round((Date.now() - startMs) / 1000)}s\n`)
 
-  return { success: committed, taskId, turns, committed, summary: finalSummary.slice(0, 200), logFile }
+  return {
+    success: committed && !aborted,
+    taskId, turns, committed, summary: finalSummary.slice(0, 200), logFile,
+    aborted: aborted || undefined,
+  }
 }
 
 // ── GitHub Copilot backend (via GitHub Copilot API - OpenAI-compatible) ──────
@@ -507,7 +571,8 @@ async function runViaCopilot(
   task: AahpTask,
   copilotToken: string,
   onLog: (msg: string) => void,
-  timeoutMs: number = 10 * 60 * 1000
+  timeoutMs: number = 10 * 60 * 1000,
+  abortSignal?: AbortSignal
 ): Promise<AgentResult> {
   const systemPrompt = buildSystemPrompt(project, taskId, task)
   const logFile = agentLogPath(project.name, project.repoPath)
@@ -535,6 +600,7 @@ async function runViaCopilot(
   let committed = false
   let finalSummary = ''
   let timedOut = false
+  let aborted = false
   const deadline = Date.now() + timeoutMs
 
   onLog(`\nGitHub Copilot agent starting on [${taskId}]: ${task.title}`)
@@ -548,6 +614,11 @@ async function runViaCopilot(
       timedOut = true
       break
     }
+    if (abortSignal?.aborted) {
+      onLog(`\nCopilot agent aborted by control endpoint`)
+      aborted = true
+      break
+    }
 
     turns++
     onLog(`\n-- Turn ${turns}/${MAX_TURNS} --`)
@@ -556,6 +627,9 @@ async function runViaCopilot(
     // Per-request timeout: remaining wall-clock time, capped at 2 minutes per request
     const perRequestMs = Math.min(deadline - Date.now(), 2 * 60 * 1000)
     const reqTimer = setTimeout(() => ac.abort(), perRequestMs)
+    // Forward external abort (issue #28) to the in-flight HTTP request
+    const externalAbortHandler = () => ac.abort()
+    if (abortSignal) abortSignal.addEventListener('abort', externalAbortHandler, { once: true })
 
     let response: Response
     try {
@@ -578,15 +652,22 @@ async function runViaCopilot(
       })
     } catch (err) {
       clearTimeout(reqTimer)
+      if (abortSignal) abortSignal.removeEventListener('abort', externalAbortHandler)
       if (ac.signal.aborted) {
-        onLog(`\nCopilot request aborted (timeout)`)
-        timedOut = true
+        if (abortSignal?.aborted) {
+          onLog(`\nCopilot agent aborted by control endpoint`)
+          aborted = true
+        } else {
+          onLog(`\nCopilot request aborted (timeout)`)
+          timedOut = true
+        }
         break
       }
       onLog(`\nNetwork error: ${String(err)}`)
       break
     }
     clearTimeout(reqTimer)
+    if (abortSignal) abortSignal.removeEventListener('abort', externalAbortHandler)
 
     if (!response.ok) {
       const body = await response.text()
@@ -646,9 +727,14 @@ async function runViaCopilot(
   if (timedOut) onLog(`\nAgent was stopped due to timeout after ${turns} turns`)
 
   writeLog(logFile, `\n${'─'.repeat(60)}\n`)
-  writeLog(logFile, `[${ts()}] AAHP ${committed ? 'DONE  ' : 'FAILED'}  ${taskId} · committed:${committed} · ${Math.round((Date.now() - startMs) / 1000)}s\n`)
+  const copilotStatus = aborted ? 'ABORT ' : (committed ? 'DONE  ' : 'FAILED')
+  writeLog(logFile, `[${ts()}] AAHP ${copilotStatus}  ${taskId} · committed:${committed} · ${Math.round((Date.now() - startMs) / 1000)}s\n`)
 
-  return { success: committed, taskId, turns, committed, summary: finalSummary.slice(0, 200), logFile }
+  return {
+    success: committed && !aborted,
+    taskId, turns, committed, summary: finalSummary.slice(0, 200), logFile,
+    aborted: aborted || undefined,
+  }
 }
 
 function markTaskDone(project: AahpProject, taskId: string, task: AahpTask, turns: number, agentName: string) {
@@ -752,7 +838,8 @@ export async function runAgent(
   explicitBackend: 'auto' | 'claude' | 'gemini' | 'codex' | 'copilot' | 'sdk' = 'auto',
   timeoutMinutes: number = 10,
   retryOptions?: RetryOptions,
-  model?: string
+  model?: string,
+  abortSignal?: AbortSignal
 ): Promise<AgentResult> {
   const { backend, copilotToken } = await resolveBackend(apiKey, explicitBackend)
   const timeoutMs = timeoutMinutes * 60 * 1000
@@ -777,11 +864,11 @@ export async function runAgent(
   }
 
   const run = (): Promise<AgentResult> => {
-    if (backend === 'claude-cli') return runViaClaudeCLI(project, taskId, task, onLog, timeoutMs)
-    if (backend === 'gemini')     return runViaGeminiCLI(project, taskId, task, onLog, timeoutMs, model)
-    if (backend === 'codex')      return runViaCodexCLI(project, taskId, task, onLog, timeoutMs, model)
-    if (backend === 'copilot')    return runViaCopilot(project, taskId, task, copilotToken, onLog, timeoutMs)
-    return runViaSDK(project, taskId, task, apiKey, onLog, timeoutMs, model)
+    if (backend === 'claude-cli') return runViaClaudeCLI(project, taskId, task, onLog, timeoutMs, abortSignal)
+    if (backend === 'gemini')     return runViaGeminiCLI(project, taskId, task, onLog, timeoutMs, model, abortSignal)
+    if (backend === 'codex')      return runViaCodexCLI(project, taskId, task, onLog, timeoutMs, model, abortSignal)
+    if (backend === 'copilot')    return runViaCopilot(project, taskId, task, copilotToken, onLog, timeoutMs, abortSignal)
+    return runViaSDK(project, taskId, task, apiKey, onLog, timeoutMs, model, abortSignal)
   }
 
   if (!retryOptions) return run()

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -13,6 +13,7 @@ import { loadConfig, saveConfig, registerScheduler, unregisterScheduler } from '
 import { StatusBoard, AgentStatus, LOG_DIR, agentLogPath, writeLog } from './status-board.js'
 import { recordMetric, loadMetrics, summarizeMetrics, metricsFilePath, getAvgDuration } from './metrics-store.js'
 import { sendAlert } from './alerting.js'
+import { startControlServer, type ControlServer } from './control-server.js'
 import { execSync } from 'child_process'
 
 const DEFAULT_ROOT= process.env['AAHP_ROOT'] ?? path.join(os.homedir(), 'Development')
@@ -498,6 +499,16 @@ program
       const limitLabel = maxConcurrent > 0 ? ` (max ${maxConcurrent} at a time)` : ' in parallel'
       console.log(chalk.bold(`\n🚀 Spawning ${targets.length} agents${limitLabel}...`))
 
+      // Issue #28: start localhost control server so the hub can POST /abort.
+      // Port is published to ~/.aahp/sessions.json under controlPort.
+      let ctrlServer: ControlServer | undefined
+      try {
+        ctrlServer = await startControlServer()
+        console.log(chalk.gray(`   Control endpoint: http://127.0.0.1:${ctrlServer.port}/abort`))
+      } catch (err) {
+        console.log(chalk.yellow(`   Warning: control server failed to start (${(err as Error).message}). Abort endpoint unavailable.`))
+      }
+
       // Build status entries, one per target
       const statuses: AgentStatus[] = targets.map(p => {
         const top = getTopTask(p)
@@ -553,25 +564,38 @@ program
             // secure-dev-ai scan failed - continue without blocking
           }
 
-          const result = await runAgent(project, taskId, task, apiKey, msg => {
-            // Only update the last meaningful line for the status board (skip blanks)
-            const line = msg.replace(/\x1B\[[0-9;]*m/g, '').split('\n').reverse().find(l => l.trim())
-            if (line) st.lastLine = line.trim()
+          // Issue #28: register this agent with the control server so it can be aborted
+          const abortCtrl = new AbortController()
+          ctrlServer?.register({
+            repoName: project.name,
+            taskId,
+            abort: () => abortCtrl.abort(),
+          })
 
-            // Extract turn progress from SDK/Copilot output (e.g., "-- Turn 5/30 --")
-            const turnMatch = msg.match(/Turn (\d+)\/(\d+)/)
-            if (turnMatch) {
-              st.currentTurn = parseInt(turnMatch[1]!, 10)
-              st.maxTurns = parseInt(turnMatch[2]!, 10)
-            }
+          let result
+          try {
+            result = await runAgent(project, taskId, task, apiKey, msg => {
+              // Only update the last meaningful line for the status board (skip blanks)
+              const line = msg.replace(/\x1B\[[0-9;]*m/g, '').split('\n').reverse().find(l => l.trim())
+              if (line) st.lastLine = line.trim()
 
-            board.refresh()
-          }, backend, timeoutMinutes, undefined, model)
+              // Extract turn progress from SDK/Copilot output (e.g., "-- Turn 5/30 --")
+              const turnMatch = msg.match(/Turn (\d+)\/(\d+)/)
+              if (turnMatch) {
+                st.currentTurn = parseInt(turnMatch[1]!, 10)
+                st.maxTurns = parseInt(turnMatch[2]!, 10)
+              }
 
-          st.state = result.success ? 'done' : 'failed'
+              board.refresh()
+            }, backend, timeoutMinutes, undefined, model, abortCtrl.signal)
+          } finally {
+            ctrlServer?.unregister(project.name, taskId)
+          }
+
+          st.state = result.aborted ? 'failed' : (result.success ? 'done' : 'failed')
           st.committed = result.committed
           st.finishedAt = new Date()
-          st.lastLine = result.success ? `committed` : 'no commit detected'
+          st.lastLine = result.aborted ? 'aborted' : (result.success ? 'committed' : 'no commit detected')
           board.refresh()
 
           recordMetric({
@@ -586,6 +610,7 @@ program
             committed: result.committed,
             cpuAvg: result.cpuAvg,
             memPeakMB: result.memPeakMB,
+            aborted: result.aborted,
           })
 
           return result
@@ -594,6 +619,8 @@ program
           st.finishedAt = new Date()
           st.lastLine = String(err).slice(0, 60)
           board.refresh()
+          // Defensive: in case the agent threw before our finally ran
+          ctrlServer?.unregister(project.name, taskId)
 
           recordMetric({
             timestamp: new Date().toISOString(),
@@ -738,12 +765,15 @@ program
             fSt.state = 'running'
             fSt.startedAt = new Date()
             followBoard.refresh()
+            // Issue #28: register follow-up agent for abort support
+            const fAbort = new AbortController()
+            ctrlServer?.register({ repoName: project.name, taskId: fTaskId, abort: () => fAbort.abort() })
             try {
               const result = await runAgent(project, fTaskId, fTask, apiKey, msg => {
                 const line = msg.replace(/\x1B\[[0-9;]*m/g, '').split('\n').reverse().find(l => l.trim())
                 if (line) fSt.lastLine = line.trim()
                 followBoard.refresh()
-              }, backend, timeoutMinutes, undefined, model)
+              }, backend, timeoutMinutes, undefined, model, fAbort.signal)
               fSt.state = result.committed ? 'done' : 'failed'
               fSt.committed = result.committed
               fSt.finishedAt = new Date()
@@ -752,7 +782,8 @@ program
               recordMetric({ timestamp: new Date().toISOString(), repo: project.name, taskId: fTaskId,
                 taskTitle: fTask.title, backend,
                 durationMs: (fSt.finishedAt?.getTime() ?? 0) - (fSt.startedAt?.getTime() ?? 0),
-                turns: result.turns, success: result.committed, committed: result.committed })
+                turns: result.turns, success: result.committed, committed: result.committed,
+                aborted: result.aborted })
               return result
             } catch (err) {
               fSt.state = 'failed'
@@ -760,6 +791,8 @@ program
               fSt.lastLine = String(err).slice(0, 60)
               followBoard.refresh()
               return undefined
+            } finally {
+              ctrlServer?.unregister(project.name, fTaskId)
             }
           })
 
@@ -771,12 +804,25 @@ program
         }
       }
 
+      // Issue #28: tear down the control server now that all agents (including
+      // any follow-up rounds) are done. Removes `controlPort` from sessions.json.
+      await ctrlServer?.stop()
       return
     }
 
     // Sequential mode (single project or interactive)
     // When --follow-up is set, keep looping until no more tasks remain in any of the target repos.
     const seqProjectNames = new Set(targets.map(p => p.name))
+
+    // Issue #28: also expose a control endpoint in sequential mode
+    let seqCtrl: ControlServer | undefined
+    try {
+      seqCtrl = await startControlServer()
+      console.log(chalk.gray(`Control endpoint: http://127.0.0.1:${seqCtrl.port}/abort`))
+    } catch (err) {
+      console.log(chalk.yellow(`Warning: control server failed to start (${(err as Error).message}). Abort endpoint unavailable.`))
+    }
+
     let seqRound = 0
     const MAX_SEQ_ROUNDS = 50
     // eslint-disable-next-line no-constant-condition
@@ -846,8 +892,11 @@ program
         }
 
         const seqStart = Date.now()
+        // Issue #28: register sequential agent for abort support
+        const seqAbort = new AbortController()
+        seqCtrl?.register({ repoName: project.name, taskId, abort: () => seqAbort.abort() })
         try {
-          const result = await runAgent(project, taskId, task, apiKey, msg => console.log(chalk.gray(msg)), backend, timeoutMinutes, undefined, model)
+          const result = await runAgent(project, taskId, task, apiKey, msg => console.log(chalk.gray(msg)), backend, timeoutMinutes, undefined, model, seqAbort.signal)
 
           recordMetric({
             timestamp: new Date().toISOString(),
@@ -861,9 +910,12 @@ program
             committed: result.committed,
             cpuAvg: result.cpuAvg,
             memPeakMB: result.memPeakMB,
+            aborted: result.aborted,
           })
 
-          if (result.success) {
+          if (result.aborted) {
+            console.log(chalk.yellow(`\n🛑 ${project.name} [${taskId}] aborted by control endpoint`))
+          } else if (result.success) {
             console.log(chalk.green(`\n✅ ${project.name} [${taskId}] completed in ${result.turns} turns`))
           } else {
             console.log(chalk.yellow(`\n⚠️  ${project.name} [${taskId}] finished without committing (${result.turns} turns)`))
@@ -882,6 +934,8 @@ program
             committed: false,
           })
           console.error(chalk.red(`\n❌ Agent failed on ${project.name}: ${String(err)}`))
+        } finally {
+          seqCtrl?.unregister(project.name, taskId)
         }
       }
 
@@ -891,6 +945,9 @@ program
       // Without --follow-up, run each target once and stop
       if (!opts.followUp) break
     }
+
+    // Issue #28: tear down the sequential-mode control server.
+    await seqCtrl?.stop()
   })
 
 // ── config ────────────────────────────────────────────────────────────────────

--- a/src/control-server.test.ts
+++ b/src/control-server.test.ts
@@ -1,0 +1,252 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest'
+import * as fs from 'fs'
+import * as path from 'path'
+import * as os from 'os'
+import { startControlServer, type ControlServer } from './control-server.js'
+
+/**
+ * Tests for the issue #28 control server. Each test gets its own temp
+ * sessions.json so we never touch the real ~/.aahp/sessions.json.
+ */
+
+let tmpDir: string
+let sessionsFile: string
+let server: ControlServer | undefined
+
+beforeEach(() => {
+  tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'aahp-control-test-'))
+  sessionsFile = path.join(tmpDir, 'sessions.json')
+  server = undefined
+})
+
+afterEach(async () => {
+  await server?.stop()
+  fs.rmSync(tmpDir, { recursive: true, force: true })
+})
+
+/** Helper: tiny http POST against the loopback server. */
+async function postJson(port: number, urlPath: string, body: unknown, method: string = 'POST'): Promise<{ status: number; body: any }> {
+  const res = await fetch(`http://127.0.0.1:${port}${urlPath}`, {
+    method,
+    headers: method === 'POST' ? { 'Content-Type': 'application/json' } : undefined,
+    body: method === 'POST' ? JSON.stringify(body) : undefined,
+  })
+  let parsed: any
+  try { parsed = await res.json() } catch { parsed = null }
+  return { status: res.status, body: parsed }
+}
+
+describe('control-server lifecycle', () => {
+  it('binds to a random localhost port and writes controlPort to sessions.json', async () => {
+    server = await startControlServer({ sessionsFile })
+    expect(server.port).toBeGreaterThan(0)
+    expect(server.port).toBeLessThan(65536)
+
+    // sessions.json should now contain { controlPort: <port> }
+    const data = JSON.parse(fs.readFileSync(sessionsFile, 'utf8'))
+    expect(data.controlPort).toBe(server.port)
+  })
+
+  it('preserves existing sessions.json keys when adding controlPort', async () => {
+    fs.writeFileSync(sessionsFile, JSON.stringify({
+      sessions: [{ repoPath: '/x', repoName: 'x' }],
+      somethingElse: 42,
+    }))
+    server = await startControlServer({ sessionsFile })
+    const data = JSON.parse(fs.readFileSync(sessionsFile, 'utf8'))
+    expect(data.controlPort).toBe(server.port)
+    expect(data.somethingElse).toBe(42)
+    expect(Array.isArray(data.sessions)).toBe(true)
+    expect(data.sessions[0].repoName).toBe('x')
+  })
+
+  it('removes controlPort from sessions.json on stop()', async () => {
+    fs.writeFileSync(sessionsFile, JSON.stringify({ sessions: ['preexisting'] }))
+    server = await startControlServer({ sessionsFile })
+    await server.stop()
+    server = undefined  // prevent double-stop in afterEach
+
+    const data = JSON.parse(fs.readFileSync(sessionsFile, 'utf8'))
+    expect(data.controlPort).toBeUndefined()
+    // unrelated keys preserved
+    expect(data.sessions).toEqual(['preexisting'])
+  })
+
+  it('survives malformed sessions.json (treats as empty object)', async () => {
+    fs.writeFileSync(sessionsFile, '{ this is not valid json')
+    server = await startControlServer({ sessionsFile })
+    expect(server.port).toBeGreaterThan(0)
+
+    // After start, the malformed content is replaced with a clean object containing controlPort.
+    const data = JSON.parse(fs.readFileSync(sessionsFile, 'utf8'))
+    expect(data.controlPort).toBe(server.port)
+  })
+})
+
+describe('control-server registry', () => {
+  it('starts empty', async () => {
+    server = await startControlServer({ sessionsFile })
+    expect(server.size()).toBe(0)
+  })
+
+  it('register/unregister tracks active agents', async () => {
+    server = await startControlServer({ sessionsFile })
+    server.register({ repoName: 'a', taskId: 'T-001', abort: () => { /* noop */ } })
+    server.register({ repoName: 'b', taskId: 'T-002', abort: () => { /* noop */ } })
+    expect(server.size()).toBe(2)
+
+    server.unregister('a', 'T-001')
+    expect(server.size()).toBe(1)
+
+    server.unregister('b', 'T-002')
+    expect(server.size()).toBe(0)
+  })
+})
+
+describe('control-server HTTP endpoint', () => {
+  it('POST /abort triggers the registered handle and returns 200', async () => {
+    server = await startControlServer({ sessionsFile })
+    let aborted = false
+    server.register({
+      repoName: 'my-repo',
+      taskId: 'T-007',
+      abort: () => { aborted = true },
+    })
+
+    const { status, body } = await postJson(server.port, '/abort', { repoName: 'my-repo', taskId: 'T-007' })
+    expect(status).toBe(200)
+    expect(body.aborted).toBe(true)
+    expect(body.repoName).toBe('my-repo')
+    expect(body.taskId).toBe('T-007')
+    expect(aborted).toBe(true)
+  })
+
+  it('returns 404 for unknown session', async () => {
+    server = await startControlServer({ sessionsFile })
+    const { status, body } = await postJson(server.port, '/abort', { repoName: 'ghost', taskId: 'T-999' })
+    expect(status).toBe(404)
+    expect(body.error).toBe('no matching session')
+  })
+
+  it('returns 405 for non-POST methods', async () => {
+    server = await startControlServer({ sessionsFile })
+    const { status } = await postJson(server.port, '/abort', null, 'GET')
+    expect(status).toBe(405)
+  })
+
+  it('returns 404 for unknown paths', async () => {
+    server = await startControlServer({ sessionsFile })
+    const { status } = await postJson(server.port, '/wrong-path', { repoName: 'x', taskId: 'T-001' })
+    expect(status).toBe(404)
+  })
+
+  it('returns 400 for invalid JSON body', async () => {
+    server = await startControlServer({ sessionsFile })
+    const res = await fetch(`http://127.0.0.1:${server.port}/abort`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: 'this is not json',
+    })
+    expect(res.status).toBe(400)
+  })
+
+  it('returns 400 when repoName or taskId is missing', async () => {
+    server = await startControlServer({ sessionsFile })
+    const r1 = await postJson(server.port, '/abort', { repoName: 'x' })
+    expect(r1.status).toBe(400)
+    const r2 = await postJson(server.port, '/abort', { taskId: 'T-001' })
+    expect(r2.status).toBe(400)
+    const r3 = await postJson(server.port, '/abort', {})
+    expect(r3.status).toBe(400)
+  })
+
+  it('does not call abort callback for unknown session', async () => {
+    server = await startControlServer({ sessionsFile })
+    let aborted = false
+    server.register({ repoName: 'a', taskId: 'T-001', abort: () => { aborted = true } })
+    await postJson(server.port, '/abort', { repoName: 'b', taskId: 'T-001' })
+    expect(aborted).toBe(false)
+  })
+
+  it('routes correctly when multiple agents are registered', async () => {
+    server = await startControlServer({ sessionsFile })
+    let abortedA = false
+    let abortedB = false
+    server.register({ repoName: 'a', taskId: 'T-001', abort: () => { abortedA = true } })
+    server.register({ repoName: 'b', taskId: 'T-002', abort: () => { abortedB = true } })
+
+    await postJson(server.port, '/abort', { repoName: 'b', taskId: 'T-002' })
+    expect(abortedA).toBe(false)
+    expect(abortedB).toBe(true)
+  })
+
+  it('rejects oversized payloads with 413', async () => {
+    server = await startControlServer({ sessionsFile })
+    const huge = 'x'.repeat(10 * 1024)  // 10KB > 4KB cap
+    const res = await fetch(`http://127.0.0.1:${server.port}/abort`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ repoName: 'x', taskId: huge }),
+    })
+    expect(res.status).toBe(413)
+  })
+})
+
+describe('control-server cleanup', () => {
+  it('releases the port after stop()', async () => {
+    server = await startControlServer({ sessionsFile })
+    const oldPort = server.port
+    await server.stop()
+    server = undefined
+
+    // Connecting to the old port should fail. Use a short timeout so the test
+    // doesn't hang if the OS happens to reassign immediately to something else.
+    const ac = new AbortController()
+    const timer = setTimeout(() => ac.abort(), 1500)
+    try {
+      const res = await fetch(`http://127.0.0.1:${oldPort}/abort`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ repoName: 'x', taskId: 'T-1' }),
+        signal: ac.signal,
+      }).catch(err => ({ ok: false, status: 0, _err: String(err) } as any))
+      expect((res as any).status).toBe(0)
+    } finally {
+      clearTimeout(timer)
+    }
+  })
+
+  it('handles repeated stop() without throwing', async () => {
+    server = await startControlServer({ sessionsFile })
+    await server.stop()
+    await server.stop()  // second call is a no-op
+    server = undefined
+  })
+
+  it('clears agent registry on stop()', async () => {
+    server = await startControlServer({ sessionsFile })
+    server.register({ repoName: 'a', taskId: 'T-001', abort: () => { /* noop */ } })
+    expect(server.size()).toBe(1)
+    await server.stop()
+    expect(server.size()).toBe(0)
+    server = undefined
+  })
+})
+
+describe('control-server isolation (security)', () => {
+  it('binds only to 127.0.0.1, not all interfaces', async () => {
+    // We can't easily verify the bind from the address Node returns (it gives
+    // 127.0.0.1 explicitly when we passed it), but we can at least confirm
+    // that the address Node returns is the loopback we asked for.
+    server = await startControlServer({ sessionsFile })
+    // The implementation calls listen(0, '127.0.0.1') so this is by construction.
+    // This test documents the security-critical invariant.
+    const res = await fetch(`http://127.0.0.1:${server.port}/abort`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ repoName: 'x', taskId: 'T-1' }),
+    })
+    // Should at least respond (404 = no matching session is fine - server is up).
+    expect(res.status).toBe(404)
+  })
+})

--- a/src/control-server.ts
+++ b/src/control-server.ts
@@ -1,0 +1,217 @@
+import * as http from 'http'
+import * as fs from 'fs'
+import * as path from 'path'
+import * as os from 'os'
+
+/**
+ * Issue #28: HTTP control surface for `aahp run`.
+ *
+ * Exposes a tiny localhost-only HTTP endpoint that the aahp-hub can POST to
+ * in order to abort a running agent. The endpoint is bound to `127.0.0.1:0`
+ * (random port); the assigned port is written to `~/.aahp/sessions.json`
+ * under the top-level `controlPort` key so the hub can discover it without
+ * any new wiring.
+ *
+ * Security:
+ *   - 127.0.0.1 only. NEVER bind to 0.0.0.0.
+ *   - No auth at this layer; anyone with shell access can already kill the
+ *     process. The hub should be served on a trusted network.
+ *   - Only POST /abort is accepted. Everything else returns 405 / 404.
+ */
+
+const SESSIONS_FILE = path.join(os.homedir(), '.aahp', 'sessions.json')
+
+/** A handle that the run loop registers for each in-flight agent. */
+export interface AgentHandle {
+  /** Repository name (matches RunMetric.repo). */
+  repoName: string
+  /** Task ID (e.g. "T-001"). */
+  taskId: string
+  /** Triggers an abort. Implementations should be idempotent. */
+  abort: () => void
+}
+
+export interface AbortRequestBody {
+  repoName?: string
+  taskId?: string
+}
+
+export interface ControlServer {
+  /** TCP port the server is listening on (assigned by the OS). */
+  port: number
+  /** Register an in-flight agent so it can be aborted via the endpoint. */
+  register(handle: AgentHandle): void
+  /** Remove a finished agent from the registry. */
+  unregister(repoName: string, taskId: string): void
+  /** Number of currently registered agents (for tests + diagnostics). */
+  size(): number
+  /** Shut down the HTTP server and remove `controlPort` from sessions.json. */
+  stop(): Promise<void>
+}
+
+export interface StartControlServerOptions {
+  /** Override the sessions.json path (used by tests). */
+  sessionsFile?: string
+}
+
+/**
+ * Read sessions.json (best-effort). Returns `{}` when the file is missing
+ * or malformed - the orchestrator may not have populated it yet.
+ */
+function readSessionsFile(file: string): Record<string, unknown> {
+  try {
+    if (!fs.existsSync(file)) return {}
+    const raw = fs.readFileSync(file, 'utf8').trim()
+    if (!raw) return {}
+    const parsed = JSON.parse(raw)
+    return (parsed && typeof parsed === 'object' && !Array.isArray(parsed))
+      ? parsed as Record<string, unknown>
+      : {}
+  } catch {
+    return {}
+  }
+}
+
+/** Atomically merge keys into sessions.json without dropping existing data. */
+function mergeIntoSessionsFile(file: string, patch: Record<string, unknown>): void {
+  fs.mkdirSync(path.dirname(file), { recursive: true })
+  const current = readSessionsFile(file)
+  const next = { ...current, ...patch }
+  fs.writeFileSync(file, JSON.stringify(next, null, 2), 'utf8')
+}
+
+/** Remove specific keys from sessions.json (preserves the rest). */
+function removeFromSessionsFile(file: string, keys: string[]): void {
+  if (!fs.existsSync(file)) return
+  const current = readSessionsFile(file)
+  for (const k of keys) delete current[k]
+  fs.writeFileSync(file, JSON.stringify(current, null, 2), 'utf8')
+}
+
+/** Build the Map key used to look up registered agents. */
+function key(repoName: string, taskId: string): string {
+  return `${repoName}|${taskId}`
+}
+
+/**
+ * Start the control HTTP server and write `controlPort` into sessions.json.
+ *
+ * The returned `ControlServer` is the public surface for the run loop:
+ * register agents while they are alive, unregister when they finish, and
+ * call `stop()` when `aahp run` exits.
+ */
+export async function startControlServer(opts: StartControlServerOptions = {}): Promise<ControlServer> {
+  const sessionsFile = opts.sessionsFile ?? SESSIONS_FILE
+  const agents = new Map<string, AgentHandle>()
+
+  const server = http.createServer((req, res) => {
+    // ── Method/route guard ────────────────────────────────────────────────
+    if (req.method !== 'POST') {
+      res.writeHead(405, { 'Content-Type': 'application/json', 'Allow': 'POST' })
+      res.end(JSON.stringify({ error: 'method not allowed' }))
+      return
+    }
+    if (req.url !== '/abort') {
+      res.writeHead(404, { 'Content-Type': 'application/json' })
+      res.end(JSON.stringify({ error: 'not found' }))
+      return
+    }
+
+    // ── Body parser (cap at 4KB to defend against unbounded reads) ────────
+    const chunks: Buffer[] = []
+    let total = 0
+    let aborted = false
+    req.on('data', (chunk: Buffer) => {
+      total += chunk.length
+      if (total > 4 * 1024) {
+        aborted = true
+        res.writeHead(413, { 'Content-Type': 'application/json' })
+        res.end(JSON.stringify({ error: 'payload too large' }))
+        req.destroy()
+        return
+      }
+      chunks.push(chunk)
+    })
+    req.on('end', () => {
+      if (aborted) return
+      let body: AbortRequestBody
+      try {
+        body = JSON.parse(Buffer.concat(chunks).toString('utf8') || '{}') as AbortRequestBody
+      } catch {
+        res.writeHead(400, { 'Content-Type': 'application/json' })
+        res.end(JSON.stringify({ error: 'invalid JSON body' }))
+        return
+      }
+
+      const { repoName, taskId } = body
+      if (typeof repoName !== 'string' || typeof taskId !== 'string') {
+        res.writeHead(400, { 'Content-Type': 'application/json' })
+        res.end(JSON.stringify({ error: 'repoName and taskId are required' }))
+        return
+      }
+
+      const handle = agents.get(key(repoName, taskId))
+      if (!handle) {
+        res.writeHead(404, { 'Content-Type': 'application/json' })
+        res.end(JSON.stringify({ error: 'no matching session' }))
+        return
+      }
+
+      try {
+        handle.abort()
+      } catch (err) {
+        res.writeHead(500, { 'Content-Type': 'application/json' })
+        res.end(JSON.stringify({ error: 'abort failed', detail: String(err).slice(0, 200) }))
+        return
+      }
+
+      res.writeHead(200, { 'Content-Type': 'application/json' })
+      res.end(JSON.stringify({ aborted: true, repoName, taskId }))
+    })
+    req.on('error', () => {
+      // Connection dropped mid-request. Nothing to do.
+    })
+  })
+
+  await new Promise<void>((resolve, reject) => {
+    server.once('error', reject)
+    // CRITICAL: 127.0.0.1 only. Never 0.0.0.0.
+    server.listen(0, '127.0.0.1', () => {
+      server.removeListener('error', reject)
+      resolve()
+    })
+  })
+
+  const addr = server.address()
+  if (!addr || typeof addr === 'string') {
+    throw new Error('control server address unavailable')
+  }
+  const port = addr.port
+
+  // Advertise our port via sessions.json so the hub can find us.
+  mergeIntoSessionsFile(sessionsFile, { controlPort: port })
+
+  return {
+    port,
+    register(handle: AgentHandle): void {
+      agents.set(key(handle.repoName, handle.taskId), handle)
+    },
+    unregister(repoName: string, taskId: string): void {
+      agents.delete(key(repoName, taskId))
+    },
+    size(): number {
+      return agents.size
+    },
+    async stop(): Promise<void> {
+      // Drop our advertised port first so the hub stops trying to reach us
+      // even if close() takes a moment to actually release the socket.
+      removeFromSessionsFile(sessionsFile, ['controlPort'])
+      agents.clear()
+      await new Promise<void>((resolve) => {
+        server.close(() => resolve())
+        // Force-close any keep-alive connections so close() resolves promptly.
+        server.closeAllConnections?.()
+      })
+    },
+  }
+}

--- a/src/metrics-store.ts
+++ b/src/metrics-store.ts
@@ -16,6 +16,10 @@ export interface RunMetric {
   committed: boolean
   cpuAvg?: number         // average CPU % during run
   memPeakMB?: number      // peak memory in MB
+  // ── Abort marker (issue #28) ────────────────────────────────────────────────
+  // Set to true when the run was terminated by a POST /abort from the hub.
+  // Implies success=false; lets the hub distinguish abort from natural failure.
+  aborted?: boolean
 }
 
 export interface MetricsSummary {


### PR DESCRIPTION
Closes #28. Unblocks aahp-hub **T-004**.

## Summary

While \`aahp run\` is active, exposes a tiny HTTP control endpoint on \`127.0.0.1:<random_port>\` so the hub can abort a running agent without SSH + kill. The hub discovers the port via a new top-level \`controlPort\` key in \`~/.aahp/sessions.json\` (sibling to \`sessions\`).

## API

\`\`\`
POST http://127.0.0.1:<port>/abort
Content-Type: application/json
{ "repoName": "<repo>", "taskId": "T-001" }
\`\`\`

| Status | Body | When |
|--------|------|------|
| 200 | \`{ aborted: true, repoName, taskId }\` | Found and aborted |
| 404 | \`{ error: "no matching session" }\` | Unknown agent |
| 400 | \`{ error: ... }\` | Missing fields or invalid JSON |
| 405 | \`{ error: "method not allowed" }\` | Non-POST |
| 413 | \`{ error: "payload too large" }\` | Body > 4KB |

## What changed

**New module** \`src/control-server.ts\`: pure HTTP + agent registry. \`startControlServer()\` returns a \`ControlServer\` with \`register(handle)\`, \`unregister(name, id)\`, \`size()\`, and \`stop()\`. Read-modify-write on \`sessions.json\` preserves existing keys (the orchestrator's own \`sessions\` array stays intact).

**Backend wiring** in \`src/agent.ts\`: every backend now accepts an optional \`abortSignal: AbortSignal\`:
- \`sdk\`: forwards \`{ signal }\` to \`client.messages.create()\` and checks \`signal.aborted\` between turns. AbortError caught and translated to \`aborted: true\`.
- \`copilot\`: chains external signal into the in-flight fetch's own AbortController, distinguishing external abort from per-request timeout abort.
- \`claude-cli\`, \`gemini\`, \`codex\`: SIGTERM the child process, SIGKILL after 5s.

\`AgentResult\` and \`RunMetric\` gain \`aborted?: boolean\` so the hub can distinguish "user aborted me" from "agent failed naturally". Aborted runs are recorded with \`success=false\`.

**CLI lifecycle** in \`src/cli.ts\`: \`aahp run\` starts one ControlServer per run mode:
- Parallel (\`--all --yes\`): server lives until follow-up rounds finish.
- Sequential: server lives until the seqRound loop ends.

Each agent gets its own AbortController; the handle's \`.abort()\` calls it. Handle is unregistered in a finally block so a thrown agent doesn't leak entries.

## Security

- **127.0.0.1 only.** Verified by code (\`server.listen(0, '127.0.0.1', ...)\`).
- No auth at this layer (anyone with shell access could already kill the process). Document that the hub should be served on a trusted network.
- Body cap of 4KB.
- Method/path strictly enforced - everything except \`POST /abort\` returns 405 or 404.

## Tests

19 new in \`src/control-server.test.ts\`:

| Group | What |
|-------|------|
| lifecycle | port assignment, sessions.json merge, malformed sessions, controlPort cleanup on stop |
| registry | empty / register / unregister sizing |
| HTTP endpoint | abort routing (200), unknown session (404), wrong method (405), wrong path (404), invalid JSON (400), missing fields (400), 413 for oversized payload, multi-agent routing |
| cleanup | port released after stop(), idempotent stop(), registry cleared on stop() |
| security | binds to 127.0.0.1 only |

\`npm run build\` clean. \`npm test\` passes 209/209 (was 190).

## Manual smoke test

\`\`\`bash
# Terminal 1
aahp run --all --yes
# -> "Control endpoint: http://127.0.0.1:54321/abort"

# Terminal 2
curl -X POST http://127.0.0.1:54321/abort \
  -H 'Content-Type: application/json' \
  -d '{"repoName":"my-repo","taskId":"T-001"}'
# -> {"aborted":true,"repoName":"my-repo","taskId":"T-001"}
\`\`\`

## Hub-side follow-up

Once this lands, the hub (T-004) reads \`~/.aahp/sessions.json\`, picks up \`controlPort\`, and POSTs to \`/abort\` from its UI.