### PR TITLE
chore(handoff): refresh manifest commit-pointer (fix CI Layer 3 after squash-merge)

### DIFF
--- a/.ai/handoff/MANIFEST.json
+++ b/.ai/handoff/MANIFEST.json
@@ -3,9 +3,9 @@
   "project": "aahp-runner",
   "last_session": {
     "agent": "claude-opus-4-8",
-    "session_id": "cli-1782532503",
-    "timestamp": "2026-06-27T03:55:04Z",
-    "commit": "93258bd",
+    "session_id": "cli-1782534238",
+    "timestamp": "2026-06-27T04:23:58Z",
+    "commit": "f8b41d4",
     "phase": "implementation",
     "duration_minutes": 0
   },


### PR DESCRIPTION
## Why

Squash-merging the OIDC migration PR replaced the branch commits with a single new commit on `main`. The handoff `MANIFEST.last_session.commit` still pointed at a branch commit that the squash discarded, so that commit is no longer an ancestor of `main` HEAD. CI "AAHP Verify" Layer 3 (commit-pointer freshness) fails on `main` as a result.

## Fix

Regenerate `MANIFEST.json` so `last_session.commit` points at the current `main` HEAD, which becomes this commit's parent (a valid ancestor). Layer 3 passes again. Only the manifest pointer + session/timestamp change.

## Process note

Squash-merge structurally breaks AAHP Layer 3 for gated repos because the manifest pointer references a branch commit that the squash drops. Future PRs to AAHP-gated repos should either merge with a merge commit (preserves branch ancestry) or include a post-merge manifest refresh like this one.