### PR TITLE
chore(ci): re-pin supply-chain-guard to v5.2.37 + enable Dependabot

### DIFF
--- a/.ai/handoff/MANIFEST.json
+++ b/.ai/handoff/MANIFEST.json
@@ -1,54 +1,54 @@
 {
   "aahp_version": "3.0",
-  "project": "aahp-runner",
+  "project": "repo",
   "last_session": {
     "agent": "claude-opus-4-8",
-    "session_id": "cli-1782534238",
-    "timestamp": "2026-06-27T04:23:58Z",
-    "commit": "f8b41d4",
+    "session_id": "cli-1782536903",
+    "timestamp": "2026-06-27T05:08:25Z",
+    "commit": "0e45725",
     "phase": "implementation",
     "duration_minutes": 0
   },
   "files": {
     "STATUS.md": {
-      "checksum": "sha256:7178a3b265a0eca5e79605c9c9f4df51721fedf27dc58afaf4abb1e7cfb85119",
-      "updated": "2026-06-27T03:53:59Z",
-      "lines": 133,
+      "checksum": "sha256:4a7097247c5a36e3eda2ce67d2a6cad71bfa14ea33f4dbfcc37698d3a36ed77f",
+      "updated": "2026-06-27T05:08:10Z",
+      "lines": 135,
       "summary": "(no summary available)"
     },
     "NEXT_ACTIONS.md": {
       "checksum": "sha256:bde8b9661ea8644077cd65847a9813a0b1dac01376a042827815742ce19c26e9",
-      "updated": "2026-06-27T03:53:59Z",
+      "updated": "2026-06-27T05:06:46Z",
       "lines": 74,
       "summary": "(no summary available)"
     },
     "LOG.md": {
       "checksum": "sha256:f76952b5c0c72c9abda510f8574b6bf77240e822e80d9fda78768b5a7e522a9b",
-      "updated": "2026-06-27T03:53:59Z",
+      "updated": "2026-06-27T05:06:46Z",
       "lines": 194,
       "summary": "(no summary available)"
     },
     "DASHBOARD.md": {
       "checksum": "sha256:c80de38f9d2658c6c1ad8ccbc326379902781b410373e1413a76bf245178bbc4",
-      "updated": "2026-06-27T03:53:59Z",
+      "updated": "2026-06-27T05:06:46Z",
       "lines": 112,
       "summary": "(no summary available)"
     },
     "TRUST.md": {
       "checksum": "sha256:0f5c0ac30be972af0f9dfa0f9c36e1a2e23dad1d29de6d61caa5b30348ceaa17",
-      "updated": "2026-06-27T03:53:59Z",
+      "updated": "2026-06-27T05:06:46Z",
       "lines": 76,
       "summary": "(no summary available)"
     },
     "CONVENTIONS.md": {
       "checksum": "sha256:97635258e88ec1719ebea8000b7568697bf212002aa7d5b5f4490a7f67bf6f93",
-      "updated": "2026-06-27T03:53:59Z",
+      "updated": "2026-06-27T05:06:46Z",
       "lines": 120,
       "summary": "(no summary available)"
     },
     "WORKFLOW.md": {
       "checksum": "sha256:17b2ba9bb1562a7bd3d0686bbaa8f1d54101949606e83717fbdfe956feeb4d05",
-      "updated": "2026-06-27T03:53:59Z",
+      "updated": "2026-06-27T05:06:46Z",
       "lines": 132,
       "summary": "(no summary available)"
     }
@@ -56,7 +56,7 @@
   "quick_context": "(no summary available) (no summary available) ",
   "token_budget": {
     "manifest_only": 85,
-    "manifest_plus_core": 1922,
-    "full_read": 7497
+    "manifest_plus_core": 1945,
+    "full_read": 7520
   }
 }

--- a/.ai/handoff/STATUS.md
+++ b/.ai/handoff/STATUS.md
@@ -131,3 +131,5 @@ _AAHP verify gate: v3.0.2 synced 2026-06-20._
 > 2026-06-21 ci(aahp): fix unquoted next_task_id + lint-handoff noreply@ PII exclusion.
 
 > 2026-06-27 ci: migrate npm publish to OIDC trusted publishing (supply-chain-guard pattern); publish + release jobs integrated into ci.yml (semver-tag + workflow_dispatch triggered, --provenance, id-token write, no NPM_TOKEN); removed token-based auto-publish.yml.
+
+> 2026-06-27 ci: re-pin supply-chain-guard to v5.2.37 (be1d718b17cc38e4bce7fa48579b7112e557943b) for the PR-comment crash fix; enabled Dependabot github-actions weekly updates.

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,4 +8,8 @@ updates:
     open-pull-requests-limit: 5
     labels:
       - "dependencies"
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
 

--- a/.github/workflows/supply-chain-guard.yml
+++ b/.github/workflows/supply-chain-guard.yml
@@ -18,7 +18,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: homeofe/supply-chain-guard@89a0f2c97ff866b939b9adf8709d8b431683d937  # v5.2.35
+      - uses: homeofe/supply-chain-guard@be1d718b17cc38e4bce7fa48579b7112e557943b  # v5.2.37
         with:
           fail-on: critical
           comment-on-pr: true


### PR DESCRIPTION
Re-pins the supply-chain-guard action from v5.2.35 (89a0f2c97ff866b939b9adf8709d8b431683d937) to v5.2.37 (be1d718b17cc38e4bce7fa48579b7112e557943b), which includes the PR-comment crash fix (no more red Scan), and enables weekly Dependabot github-actions updates.