### PR TITLE
docs(readme): add AAHP Verify + CI badges

### DIFF
--- a/.ai/handoff/MANIFEST.json
+++ b/.ai/handoff/MANIFEST.json
@@ -3,52 +3,52 @@
   "project": "repo",
   "last_session": {
     "agent": "claude-opus-4-8",
-    "session_id": "cli-1782536903",
-    "timestamp": "2026-06-27T05:08:25Z",
-    "commit": "0e45725",
+    "session_id": "cli-1782541124",
+    "timestamp": "2026-06-27T06:18:46Z",
+    "commit": "765d274",
     "phase": "implementation",
     "duration_minutes": 0
   },
   "files": {
     "STATUS.md": {
-      "checksum": "sha256:4a7097247c5a36e3eda2ce67d2a6cad71bfa14ea33f4dbfcc37698d3a36ed77f",
-      "updated": "2026-06-27T05:08:10Z",
-      "lines": 135,
+      "checksum": "sha256:e8b780b34820f2ee6b9e08350cf70f966a20720eb8fc0d2afc8faf4a38a618e5",
+      "updated": "2026-06-27T06:18:17Z",
+      "lines": 137,
       "summary": "(no summary available)"
     },
     "NEXT_ACTIONS.md": {
       "checksum": "sha256:bde8b9661ea8644077cd65847a9813a0b1dac01376a042827815742ce19c26e9",
-      "updated": "2026-06-27T05:06:46Z",
+      "updated": "2026-06-27T06:16:30Z",
       "lines": 74,
       "summary": "(no summary available)"
     },
     "LOG.md": {
       "checksum": "sha256:f76952b5c0c72c9abda510f8574b6bf77240e822e80d9fda78768b5a7e522a9b",
-      "updated": "2026-06-27T05:06:46Z",
+      "updated": "2026-06-27T06:16:30Z",
       "lines": 194,
       "summary": "(no summary available)"
     },
     "DASHBOARD.md": {
       "checksum": "sha256:c80de38f9d2658c6c1ad8ccbc326379902781b410373e1413a76bf245178bbc4",
-      "updated": "2026-06-27T05:06:46Z",
+      "updated": "2026-06-27T06:16:30Z",
       "lines": 112,
       "summary": "(no summary available)"
     },
     "TRUST.md": {
       "checksum": "sha256:0f5c0ac30be972af0f9dfa0f9c36e1a2e23dad1d29de6d61caa5b30348ceaa17",
-      "updated": "2026-06-27T05:06:46Z",
+      "updated": "2026-06-27T06:16:30Z",
       "lines": 76,
       "summary": "(no summary available)"
     },
     "CONVENTIONS.md": {
       "checksum": "sha256:97635258e88ec1719ebea8000b7568697bf212002aa7d5b5f4490a7f67bf6f93",
-      "updated": "2026-06-27T05:06:46Z",
+      "updated": "2026-06-27T06:16:30Z",
       "lines": 120,
       "summary": "(no summary available)"
     },
     "WORKFLOW.md": {
       "checksum": "sha256:17b2ba9bb1562a7bd3d0686bbaa8f1d54101949606e83717fbdfe956feeb4d05",
-      "updated": "2026-06-27T05:06:46Z",
+      "updated": "2026-06-27T06:16:30Z",
       "lines": 132,
       "summary": "(no summary available)"
     }
@@ -56,7 +56,7 @@
   "quick_context": "(no summary available) (no summary available) ",
   "token_budget": {
     "manifest_only": 85,
-    "manifest_plus_core": 1945,
-    "full_read": 7520
+    "manifest_plus_core": 1983,
+    "full_read": 7558
   }
 }

--- a/.ai/handoff/STATUS.md
+++ b/.ai/handoff/STATUS.md
@@ -133,3 +133,5 @@ _AAHP verify gate: v3.0.2 synced 2026-06-20._
 > 2026-06-27 ci: migrate npm publish to OIDC trusted publishing (supply-chain-guard pattern); publish + release jobs integrated into ci.yml (semver-tag + workflow_dispatch triggered, --provenance, id-token write, no NPM_TOKEN); removed token-based auto-publish.yml.
 
 > 2026-06-27 ci: re-pin supply-chain-guard to v5.2.37 (be1d718b17cc38e4bce7fa48579b7112e557943b) for the PR-comment crash fix; enabled Dependabot github-actions weekly updates.
+
+> 2026-06-27 docs(readme): add AAHP/CI status badges to README top (CI, AAHP Verify, Supply Chain Guard, Security/CodeQL, npm, License); only badges for workflows that exist in .github/workflows/ were added.

--- a/README.md
+++ b/README.md
@@ -2,6 +2,13 @@
 
 > Autonomous agent runner for AAHP v3 projects. Spawns Claude/Copilot agents to work through tasks across all your repos - unattended or on-demand. Includes AI-driven planning, overnight loops, and follow-up chaining.
 
+[![CI](https://github.com/homeofe/aahp-runner/actions/workflows/ci.yml/badge.svg)](https://github.com/homeofe/aahp-runner/actions/workflows/ci.yml)
+[![AAHP Verify](https://github.com/homeofe/aahp-runner/actions/workflows/aahp-verify.yml/badge.svg)](https://github.com/homeofe/aahp-runner/actions/workflows/aahp-verify.yml)
+[![Supply Chain Guard](https://github.com/homeofe/aahp-runner/actions/workflows/supply-chain-guard.yml/badge.svg)](https://github.com/homeofe/aahp-runner/actions/workflows/supply-chain-guard.yml)
+[![Security](https://github.com/homeofe/aahp-runner/actions/workflows/codeql.yml/badge.svg)](https://github.com/homeofe/aahp-runner/actions/workflows/codeql.yml)
+[![npm](https://img.shields.io/npm/v/@elvatis_com/aahp-runner.svg)](https://www.npmjs.com/package/@elvatis_com/aahp-runner)
+[![License](https://img.shields.io/badge/license-Apache--2.0-blue.svg)](LICENSE)
+
 ---
 
 ## Changelog


### PR DESCRIPTION
## What

Add status badges to the top of `README.md`, matching the canonical `homeofe/AAHP` badge style. Only badges whose workflow file actually exists in `.github/workflows/` were added:

- **CI** (`ci.yml`)
- **AAHP Verify** (`aahp-verify.yml`)
- **Supply Chain Guard** (`supply-chain-guard.yml`)
- **Security** (`codeql.yml`)
- **npm** (`@elvatis_com/aahp-runner`)
- **License** (Apache-2.0)

## AAHP handoff

This repo is AAHP-gated, so the handoff was bumped alongside the docs change:

- Appended a dated note to `.ai/handoff/STATUS.md`.
- Regenerated `.ai/handoff/MANIFEST.json` with HEAD still at the branch base, so the manifest commit-pointer matches base and a future squash keeps AAHP Verify Layer 3 green.

`bash scripts/verify-handoff.sh . --level ci` passes locally (all four layers OK; the only Layer 4 output is a pre-existing TRUST-TTL WARN unrelated to this change).

## Notes

- Docs-only plus handoff bump. No source files changed.
- English only, no em dashes.