### PR TITLE
chore(aahp): sync canonical gate scripts from improvements

### DIFF
--- a/.ai/handoff/MANIFEST.json
+++ b/.ai/handoff/MANIFEST.json
@@ -2,59 +2,59 @@
   "aahp_version": "3.0",
   "project": "aahp-runner",
   "last_session": {
-    "agent": "claude-fable-5",
-    "session_id": "cli-1783072030",
-    "timestamp": "2026-07-03T09:47:10Z",
-    "commit": "a114816",
-    "phase": "fix",
+    "agent": "claude-opus-4-8",
+    "session_id": "cli-1783874869",
+    "timestamp": "2026-07-12T16:47:49Z",
+    "commit": "69fa6b7",
+    "phase": "implementation",
     "duration_minutes": 0
   },
   "files": {
     "STATUS.md": {
-      "checksum": "sha256:aae2c8fee9bcc37baab6abac333469e915bc0e051d1491ca72688bc2426e1c4f",
-      "updated": "2026-07-03T09:47:10Z",
-      "lines": 159,
+      "checksum": "sha256:cef79e74f79d325a01250458d47b3b109132014d23e0404e93a202cac8ebe9b2",
+      "updated": "2026-07-12T16:47:48Z",
+      "lines": 161,
       "summary": "(no summary available)"
     },
     "NEXT_ACTIONS.md": {
       "checksum": "sha256:bde8b9661ea8644077cd65847a9813a0b1dac01376a042827815742ce19c26e9",
-      "updated": "2026-06-27T03:53:59Z",
+      "updated": "2026-07-12T16:47:24Z",
       "lines": 74,
       "summary": "(no summary available)"
     },
     "LOG.md": {
       "checksum": "sha256:f76952b5c0c72c9abda510f8574b6bf77240e822e80d9fda78768b5a7e522a9b",
-      "updated": "2026-06-28T06:56:55Z",
+      "updated": "2026-07-12T16:47:24Z",
       "lines": 194,
       "summary": "(no summary available)"
     },
     "DASHBOARD.md": {
       "checksum": "sha256:c80de38f9d2658c6c1ad8ccbc326379902781b410373e1413a76bf245178bbc4",
-      "updated": "2026-06-27T03:53:59Z",
+      "updated": "2026-07-12T16:47:24Z",
       "lines": 112,
       "summary": "(no summary available)"
     },
     "TRUST.md": {
       "checksum": "sha256:0f5c0ac30be972af0f9dfa0f9c36e1a2e23dad1d29de6d61caa5b30348ceaa17",
-      "updated": "2026-06-27T03:53:59Z",
+      "updated": "2026-07-12T16:47:24Z",
       "lines": 76,
       "summary": "(no summary available)"
     },
     "CONVENTIONS.md": {
       "checksum": "sha256:97635258e88ec1719ebea8000b7568697bf212002aa7d5b5f4490a7f67bf6f93",
-      "updated": "2026-06-27T03:53:59Z",
+      "updated": "2026-07-12T16:47:24Z",
       "lines": 120,
       "summary": "(no summary available)"
     },
     "WORKFLOW.md": {
       "checksum": "sha256:17b2ba9bb1562a7bd3d0686bbaa8f1d54101949606e83717fbdfe956feeb4d05",
-      "updated": "2026-06-28T06:56:55Z",
+      "updated": "2026-07-12T16:47:24Z",
       "lines": 132,
       "summary": "(no summary available)"
     },
     "pii-allowlist.json": {
       "checksum": "sha256:7c1051f6e2bc3943b7c1dbe4da229694455681b8875a346c99279e555edb733f",
-      "updated": "2026-06-30T08:34:15Z",
+      "updated": "2026-07-12T16:47:24Z",
       "lines": 4,
       "summary": "{"
     }
@@ -62,8 +62,8 @@
   "quick_context": "(no summary available) (no summary available) ",
   "token_budget": {
     "manifest_only": 85,
-    "manifest_plus_core": 2268,
-    "full_read": 7851
+    "manifest_plus_core": 2299,
+    "full_read": 7882
   }
   ,"next_task_id": "4"
   ,"tasks": {"T-001":{"title":"[T-014] - HTTP /abort endpoint for running agents","status":"in_progress","priority":"medium","depends_on":[],"created":"2026-06-28T10:10:32.124Z","notes":"**AAHP Task:** `T-014`  \n**Status:** in_progress  \n**Priority:** medium  \n\n\n\n\n---\n*Auto-created from AAHP manifest · project: aahp-runner*","github_issue":50,"github_repo":"homeofe/aahp-runner"},"T-002":{"title":"[T-013] - Capture LLM token totals in RunMetric","status":"in_progress","priority":"medium","depends_on":[],"created":"2026-06-28T10:10:32.124Z","notes":"**AAHP Task:** `T-013`  \n**Status:** in_progress  \n**Priority:** medium  \n\n\n\n\n---\n*Auto-created from AAHP manifest · project: aahp-runner*","github_issue":49,"github_repo":"homeofe/aahp-runner"},"T-003":{"title":"aahp run should publish live agents to sessions.json (consumed by aahp-hub live view)","status":"ready","priority":"medium","depends_on":[],"created":"2026-06-28T10:10:32.125Z","notes":"## What is happening\n\n`aahp run` spawns N agents in parallel. The terminal status board renders them\nlive (in-memory). The control endpoint advertises its port via\n`~/.aahp/sessions.json`. **But the `sessions: []` array stays empty** while\nthe agents are running.\n\nThat makes the hub think no agents are running even when 16 are mid-flight.\nRepro from a real session this evening:\n\n```\n$ cat ~/.aahp/sessions.json\n{ \"updatedAt\": \"2026-04-25T13:01:21.714Z\",\n  \"sessions\": [],\n  \"controlPort\": 48237 }\n","github_issue":31,"github_repo":"homeofe/aahp-runner"}}

--- a/.ai/handoff/STATUS.md
+++ b/.ai/handoff/STATUS.md
@@ -1,5 +1,7 @@
 # aahp-runner: Current State of the Nation
 
+> Note (2026-07-12, claude-opus-4-8): synced canonical AAHP gate scripts from homeofe/improvements (adds the realpath-relative PII validator invocation that fixes the Windows/MSYS artifact; AAHP_HANDOFF_FILES preserved).
+
 > Last updated: 2026-06-28 by claude-opus-4-8
 > Commit: 9068353 (latest on main)
 >

--- a/scripts/_aahp-lib.sh
+++ b/scripts/_aahp-lib.sh
@@ -2,7 +2,17 @@
 # _aahp-lib.sh -Shared functions for AAHP tooling
 # Not intended to be run directly. Source this from other scripts.
 
-# Standard AAHP handoff files, in canonical order
+# Standard AAHP handoff files, in canonical order.
+#
+# PER-REPO CONFIG: this single line is the one legitimate point of variation
+# across consumer repos. It is the DEFAULT / superset used for a fresh install;
+# a consumer that tracks fewer files (e.g. no LOG-ARCHIVE.* or no
+# pii-allowlist.json) keeps its own narrower list. scripts/sync-gate-scripts.sh
+# treats exactly this line as per-repo-preserved: when it copies the canonical
+# gate scripts into a consumer it reads the consumer's existing
+# AAHP_HANDOFF_FILES=(...) line and substitutes it back in, so a sync never
+# overwrites a repo's tracked-file set. aahp-manifest.sh only indexes files that
+# actually exist, so listing a file a repo does not have is harmless.
 # shellcheck disable=SC2034
 AAHP_HANDOFF_FILES=(STATUS.md NEXT_ACTIONS.md LOG.md DASHBOARD.md TRUST.md CONVENTIONS.md WORKFLOW.md pii-allowlist.json)
 
@@ -50,7 +60,11 @@ aahp_line_count() {
 aahp_auto_summary() {
     local filepath="$1"
     local summary
+    # Strip CR so a CRLF working tree (Windows) yields the same summary as an
+    # LF checkout (Linux CI). The summary is written to the non-checksummed
+    # "summary" field, so this is a cosmetic robustness fix, not a gate change.
     summary=$(head -5 "$filepath" \
+        | tr -d '\r' \
         | grep -v '^#' | grep -v '^>' | grep -v '^---' | grep -v '^$' \
         | head -1 | cut -c1-150 || true)
     [ -z "$summary" ] && summary="(no summary available)"

--- a/scripts/aahp-manifest.sh
+++ b/scripts/aahp-manifest.sh
@@ -76,7 +76,18 @@ esac
 
 # ─── Detect project metadata ─────────────────────────────────
 
-PROJECT_NAME=$(basename "$(cd "$PROJECT_ROOT" && pwd)")
+# Project name: PRESERVE the existing MANIFEST.json "project" value on
+# regeneration; only derive it from the directory basename on first-ever
+# generation. Without this, regenerating inside a differently-named checkout
+# (e.g. the gate-sync bot's mktemp working copy, or any tarball/CI dir) would
+# overwrite a consumer's real project name with the temp-dir basename.
+PROJECT_NAME=""
+if [ -f "$HANDOFF_DIR/MANIFEST.json" ]; then
+    PROJECT_NAME="$(aahp_manifest_field "$HANDOFF_DIR/MANIFEST.json" "project")"
+fi
+if [ -z "$PROJECT_NAME" ]; then
+    PROJECT_NAME=$(basename "$(cd "$PROJECT_ROOT" && pwd)")
+fi
 COMMIT=$(cd "$PROJECT_ROOT" && git rev-parse --short HEAD 2>/dev/null || echo "unknown")
 TIMESTAMP=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
 
@@ -145,16 +156,16 @@ if [ -f "$HANDOFF_DIR/MANIFEST.json" ]; then
     # Extract tasks block and next_task_id if they exist
     if command -v node &>/dev/null; then
         EXISTING=$(node -e "
-            const m = JSON.parse(require('fs').readFileSync('$HANDOFF_DIR/MANIFEST.json', 'utf8'));
+            const m = JSON.parse(require('fs').readFileSync(process.argv[1], 'utf8'));
             if (m.tasks) process.stdout.write(JSON.stringify(m.tasks));
-        " 2>/dev/null || true)
+        " "$HANDOFF_DIR/MANIFEST.json" 2>/dev/null || true)
         if [ -n "$EXISTING" ]; then
             TASKS_JSON="$EXISTING"
         fi
         EXISTING_ID=$(node -e "
-            const m = JSON.parse(require('fs').readFileSync('$HANDOFF_DIR/MANIFEST.json', 'utf8'));
+            const m = JSON.parse(require('fs').readFileSync(process.argv[1], 'utf8'));
             if (m.next_task_id) process.stdout.write(String(m.next_task_id));
-        " 2>/dev/null || true)
+        " "$HANDOFF_DIR/MANIFEST.json" 2>/dev/null || true)
         if [ -n "$EXISTING_ID" ]; then
             NEXT_TASK_ID="$EXISTING_ID"
         fi
@@ -203,3 +214,5 @@ if [ "$QUIET" = false ]; then
     echo "MANIFEST.json generated: $FILES_FOUND files indexed, checksums current."
     echo "  Token budget: manifest=$MANIFEST_TOKENS, core=$CORE_TOKENS, full=$FULL_TOKENS"
 fi
+
+

--- a/scripts/lint-handoff.sh
+++ b/scripts/lint-handoff.sh
@@ -37,6 +37,18 @@ PROJECT_ROOT="."
 HANDOFF_DIR=".ai/handoff"
 VIOLATIONS=0
 
+# Resolve validate-pii-allowlist.py as a path RELATIVE to the (post-cd) cwd, so
+# native-Windows python is handed a relative path rather than an absolute MSYS
+# one. An absolute /c/Users/... path intermittently fails MSYS->Windows argv
+# conversion and surfaces as a mangled "C:\c\Users\...: can't open file"
+# artifact (a false Check-3 failure). realpath --relative-to is coreutils
+# (present on git-bash and Linux CI); where it is unavailable (e.g. BSD realpath
+# on macOS) we keep the absolute path, which opens fine there.
+PII_VALIDATOR="$SCRIPT_DIR/validate-pii-allowlist.py"
+if PII_VALIDATOR_REL="$(realpath --relative-to="$PWD" "$SCRIPT_DIR/validate-pii-allowlist.py" 2>/dev/null)"; then
+    PII_VALIDATOR="$PII_VALIDATOR_REL"
+fi
+
 RED='\033[0;31m'
 GREEN='\033[0;32m'
 YELLOW='\033[1;33m'
@@ -136,7 +148,7 @@ if [ -f "$ALLOWLIST_FILE" ]; then
         VIOLATIONS=$((VIOLATIONS + 1))
     else
         ALLOWLIST_ERR="$(mktemp)"
-        if ALLOWLIST_ENTRIES=$("$PYTHON_CMD" "$SCRIPT_DIR/validate-pii-allowlist.py" "$ALLOWLIST_FILE" --format tsv 2>"$ALLOWLIST_ERR"); then
+        if ALLOWLIST_ENTRIES=$("$PYTHON_CMD" "$PII_VALIDATOR" "$ALLOWLIST_FILE" --format tsv 2>"$ALLOWLIST_ERR"); then
             echo -e "  ${GREEN}OK Valid PII allowlist.${NC}"
         else
             ALLOWLIST_MESSAGE="$ALLOWLIST_ENTRIES"
@@ -170,6 +182,14 @@ PY
     fi
 fi
 
+# Locale-robustness (T-027): use grep -E (POSIX ERE), never grep -P (PCRE). GNU
+# grep -P aborts under a non-UTF-8 locale ("supports only unibyte and UTF-8
+# locales") and the pipeline then finds nothing, a silent FALSE PASS that made
+# the gate non-deterministic by locale. LC_ALL=C.UTF-8 pins byte-for-byte
+# identical detection across Windows git-bash, the commit hook, and Linux CI.
+# Per-MATCH filtering (T-029): grep -o extracts each address, awk excludes per
+# ADDRESS (not per line), so an excluded token (noreply / example.com /
+# placeholder) elsewhere on the same line can no longer mask a real address.
 EMAIL_MATCHES=$(LC_ALL=C.UTF-8 grep -rHnoE '[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}' "$HANDOFF_DIR"/*.md 2>/dev/null | awk -F: '{ addr=$NF; if (addr ~ /\.noreply\./ || addr ~ /^no-?reply@/ || index(addr,"example.com") || index(addr,"placeholder")) next; print }' || true)
 UNAPPROVED=""
 if [ -n "$EMAIL_MATCHES" ]; then

--- a/scripts/verify-handoff.sh
+++ b/scripts/verify-handoff.sh
@@ -82,7 +82,16 @@ case "$LEVEL" in
         ;;
 esac
 
-HANDOFF_DIR="$PROJECT_ROOT/.ai/handoff"
+# Path-format-agnostic file access (cross-platform fix).
+# Windows-native Python/Node cannot open an absolute MSYS path like
+# /c/Users/...; helpers that read MANIFEST.json (aahp_manifest_field) would
+# fail. Change into the project root once, then drive everything off RELATIVE
+# paths (lint-handoff.sh ".", git -C ".", '.ai/handoff/...'); these resolve
+# identically on Windows git-bash and Linux CI. SCRIPT_DIR was already resolved
+# above against $0, so sourcing/exec of sibling scripts is unaffected by the cd.
+cd "$PROJECT_ROOT" || { echo -e "${RED}Error: cannot cd into project root: $PROJECT_ROOT${NC}" >&2; exit 1; }
+PROJECT_ROOT="."
+HANDOFF_DIR=".ai/handoff"
 
 if [ ! -d "$HANDOFF_DIR" ]; then
     echo -e "${RED}Error: $HANDOFF_DIR not found.${NC}" >&2


### PR DESCRIPTION
## What

Sync the four vendored AAHP gate scripts from the canonical source (homeofe/improvements@main) into this consumer repo via `scripts/sync-gate-scripts.sh`.

Scripts updated (now byte-identical to canonical except the preserved config line):
- `scripts/_aahp-lib.sh`
- `scripts/lint-handoff.sh`
- `scripts/aahp-manifest.sh`
- `scripts/verify-handoff.sh`

## Why this matters (Windows/MSYS PII path fix)

The reconciled `lint-handoff.sh` Check [3/6] now resolves `scripts/validate-pii-allowlist.py` as a path relative to the post-cd cwd before handing it to native-Windows Python. An absolute MSYS path (`/c/Users/...`) intermittently failed the MSYS to Windows argv conversion and surfaced as a false Check-3 failure (the mangled `C:\Users...validate-pii-allowlist.py: can't open file` artifact). `verify-handoff.sh` and `aahp-manifest.sh` also pick up the matching relative-path / `process.argv` hardening from canonical.

## Config preserved

`AAHP_HANDOFF_FILES` in `scripts/_aahp-lib.sh` was preserved verbatim from this repo (`STATUS.md NEXT_ACTIONS.md LOG.md DASHBOARD.md TRUST.md CONVENTIONS.md WORKFLOW.md pii-allowlist.json`). The sync never changes a repo's tracked-file set.

## AAHP handoff

STATUS.md carries a dated sync note and MANIFEST.json was regenerated in the same commit (`scripts/aahp-manifest.sh`), so the handoff checksums stay consistent.

## Acceptance criteria

- [x] Canonical gate scripts synced (4 scripts)
- [x] Per-repo `AAHP_HANDOFF_FILES` preserved
- [x] Gate green (`verify-handoff.sh . --level ci` passes, 0 checksum mismatches)
- [x] `scripts/validate-pii-allowlist.py` present (already tracked; identical to canonical)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
