### PR TITLE
chore(aahp): sync canonical gate scripts and hook tooling from improvements

### DIFF
--- a/.ai/handoff/MANIFEST.json
+++ b/.ai/handoff/MANIFEST.json
@@ -3,58 +3,58 @@
   "project": "aahp-runner",
   "last_session": {
     "agent": "claude-opus-4-8",
-    "session_id": "cli-1784009642",
-    "timestamp": "2026-07-14T06:14:02Z",
-    "commit": "8f07bae",
-    "phase": "implementation",
+    "session_id": "cli-1784032364",
+    "timestamp": "2026-07-14T12:32:47Z",
+    "commit": "c735b68",
+    "phase": "fix",
     "duration_minutes": 0
   },
   "files": {
     "STATUS.md": {
-      "checksum": "sha256:4523530898c82d4bb19cb28194602abfc242197ac7e7564831b90f262536326b",
-      "updated": "2026-07-14T06:14:02Z",
-      "lines": 163,
+      "checksum": "sha256:2e612b542dfe8ed59fe2622ae439422b26c42348eba5b4da0c05af44e6dc1deb",
+      "updated": "2026-07-14T12:32:29Z",
+      "lines": 165,
       "summary": "(no summary available)"
     },
     "NEXT_ACTIONS.md": {
       "checksum": "sha256:bde8b9661ea8644077cd65847a9813a0b1dac01376a042827815742ce19c26e9",
-      "updated": "2026-07-14T06:14:01Z",
+      "updated": "2026-07-14T12:29:52Z",
       "lines": 74,
       "summary": "(no summary available)"
     },
     "LOG.md": {
       "checksum": "sha256:f76952b5c0c72c9abda510f8574b6bf77240e822e80d9fda78768b5a7e522a9b",
-      "updated": "2026-07-14T06:14:01Z",
+      "updated": "2026-07-14T12:29:52Z",
       "lines": 194,
       "summary": "(no summary available)"
     },
     "DASHBOARD.md": {
       "checksum": "sha256:c80de38f9d2658c6c1ad8ccbc326379902781b410373e1413a76bf245178bbc4",
-      "updated": "2026-07-14T06:14:01Z",
+      "updated": "2026-07-14T12:29:52Z",
       "lines": 112,
       "summary": "(no summary available)"
     },
     "TRUST.md": {
       "checksum": "sha256:0f5c0ac30be972af0f9dfa0f9c36e1a2e23dad1d29de6d61caa5b30348ceaa17",
-      "updated": "2026-07-14T06:14:01Z",
+      "updated": "2026-07-14T12:29:52Z",
       "lines": 76,
       "summary": "(no summary available)"
     },
     "CONVENTIONS.md": {
       "checksum": "sha256:97635258e88ec1719ebea8000b7568697bf212002aa7d5b5f4490a7f67bf6f93",
-      "updated": "2026-07-14T06:14:01Z",
+      "updated": "2026-07-14T12:29:52Z",
       "lines": 120,
       "summary": "(no summary available)"
     },
     "WORKFLOW.md": {
       "checksum": "sha256:17b2ba9bb1562a7bd3d0686bbaa8f1d54101949606e83717fbdfe956feeb4d05",
-      "updated": "2026-07-14T06:14:01Z",
+      "updated": "2026-07-14T12:29:52Z",
       "lines": 132,
       "summary": "(no summary available)"
     },
     "pii-allowlist.json": {
       "checksum": "sha256:7c1051f6e2bc3943b7c1dbe4da229694455681b8875a346c99279e555edb733f",
-      "updated": "2026-07-14T06:14:01Z",
+      "updated": "2026-07-14T12:29:52Z",
       "lines": 4,
       "summary": "{"
     }
@@ -62,8 +62,8 @@
   "quick_context": "(no summary available) (no summary available) ",
   "token_budget": {
     "manifest_only": 85,
-    "manifest_plus_core": 2355,
-    "full_read": 7938
+    "manifest_plus_core": 2400,
+    "full_read": 7983
   }
   ,"next_task_id": "4"
   ,"tasks": {"T-001":{"title":"[T-014] - HTTP /abort endpoint for running agents","status":"in_progress","priority":"medium","depends_on":[],"created":"2026-06-28T10:10:32.124Z","notes":"**AAHP Task:** `T-014`  \n**Status:** in_progress  \n**Priority:** medium  \n\n\n\n\n---\n*Auto-created from AAHP manifest · project: aahp-runner*","github_issue":50,"github_repo":"homeofe/aahp-runner"},"T-002":{"title":"[T-013] - Capture LLM token totals in RunMetric","status":"in_progress","priority":"medium","depends_on":[],"created":"2026-06-28T10:10:32.124Z","notes":"**AAHP Task:** `T-013`  \n**Status:** in_progress  \n**Priority:** medium  \n\n\n\n\n---\n*Auto-created from AAHP manifest · project: aahp-runner*","github_issue":49,"github_repo":"homeofe/aahp-runner"},"T-003":{"title":"aahp run should publish live agents to sessions.json (consumed by aahp-hub live view)","status":"ready","priority":"medium","depends_on":[],"created":"2026-06-28T10:10:32.125Z","notes":"## What is happening\n\n`aahp run` spawns N agents in parallel. The terminal status board renders them\nlive (in-memory). The control endpoint advertises its port via\n`~/.aahp/sessions.json`. **But the `sessions: []` array stays empty** while\nthe agents are running.\n\nThat makes the hub think no agents are running even when 16 are mid-flight.\nRepro from a real session this evening:\n\n```\n$ cat ~/.aahp/sessions.json\n{ \"updatedAt\": \"2026-04-25T13:01:21.714Z\",\n  \"sessions\": [],\n  \"controlPort\": 48237 }\n","github_issue":31,"github_repo":"homeofe/aahp-runner"}}

--- a/.ai/handoff/STATUS.md
+++ b/.ai/handoff/STATUS.md
@@ -1,3 +1,5 @@
+> Note (2026-07-14, claude-opus-4-8): Synced the canonical AAHP gate scripts from homeofe/improvements (v3.5.0 fixes: aahp-manifest.sh --phase documentation + cross_repo_ref preservation, lint-handoff.sh SC2034), AAHP_HANDOFF_FILES preserved, and refreshed the local hook tooling (scripts/hooks/, install-hooks.sh, verify-hooks.sh). Fleet re-sync.
+
 > Note (2026-07-14, claude-opus-4-8): Synced the canonical Layer 3 tolerance fix from homeofe/improvements. verify-handoff.sh now downgrades a non-ancestor MANIFEST.last_session.commit from FAIL to WARN so a squash-merge or rebase-merge no longer trips AAHP Verify Layer 3 on main; Layers 1-2 still gate real staleness.
 
 # aahp-runner: Current State of the Nation

--- a/scripts/aahp-manifest.sh
+++ b/scripts/aahp-manifest.sh
@@ -7,7 +7,7 @@
 # Options:
 #   --agent NAME       Agent identifier (default: "cli-tool")
 #   --session-id ID    Session identifier (default: auto-generated)
-#   --phase PHASE      Pipeline phase: research|architecture|implementation|review|fix|idle (default: "idle")
+#   --phase PHASE      Pipeline phase: research|architecture|implementation|review|fix|idle|documentation (default: "idle")
 #   --context "TEXT"    Quick context string (default: auto-generated from file summaries)
 #   --duration MIN     Session duration in minutes (default: 0)
 #   --quiet            Suppress output except errors
@@ -67,9 +67,9 @@ fi
 
 # Validate phase
 case "$PHASE" in
-    research|architecture|implementation|review|fix|idle) ;;
+    research|architecture|implementation|review|fix|idle|documentation) ;;
     *)
-        echo "Error: Invalid phase '$PHASE'. Must be one of: research, architecture, implementation, review, fix, idle" >&2
+        echo "Error: Invalid phase '$PHASE'. Must be one of: research, architecture, implementation, review, fix, idle, documentation" >&2
         exit 1
         ;;
 esac
@@ -151,6 +151,7 @@ FULL_TOKENS=$((MANIFEST_TOKENS + TOTAL_TOKENS))
 
 TASKS_JSON=""
 NEXT_TASK_ID=""
+CROSS_REPO_REF=""
 
 if [ -f "$HANDOFF_DIR/MANIFEST.json" ]; then
     # Extract tasks block and next_task_id if they exist
@@ -168,6 +169,15 @@ if [ -f "$HANDOFF_DIR/MANIFEST.json" ]; then
         " "$HANDOFF_DIR/MANIFEST.json" 2>/dev/null || true)
         if [ -n "$EXISTING_ID" ]; then
             NEXT_TASK_ID="$EXISTING_ID"
+        fi
+        # Preserve the optional cross_repo_ref field (v3.4+), like tasks it is
+        # agent-managed and must survive regeneration.
+        EXISTING_CRR=$(node -e "
+            const m = JSON.parse(require('fs').readFileSync(process.argv[1], 'utf8'));
+            if (m.cross_repo_ref) process.stdout.write(JSON.stringify(m.cross_repo_ref));
+        " "$HANDOFF_DIR/MANIFEST.json" 2>/dev/null || true)
+        if [ -n "$EXISTING_CRR" ]; then
+            CROSS_REPO_REF="$EXISTING_CRR"
         fi
     fi
 fi
@@ -203,6 +213,9 @@ MANIFEST
     fi
     if [ -n "$TASKS_JSON" ]; then
         echo "  ,\"tasks\": $TASKS_JSON"
+    fi
+    if [ -n "$CROSS_REPO_REF" ]; then
+        echo "  ,\"cross_repo_ref\": $CROSS_REPO_REF"
     fi
 
     echo "}"

--- a/scripts/install-hooks.sh
+++ b/scripts/install-hooks.sh
@@ -41,13 +41,13 @@ HOOKS_DIR=$(git -C "$TARGET" config --get core.hooksPath 2>/dev/null || true)
 if [ -n "$HOOKS_DIR" ]; then
     # core.hooksPath may be relative to the repo root.
     case "$HOOKS_DIR" in
-        /* | [A-Za-z]:*) : ;;  # POSIX-absolute or Windows drive-letter (C:/...) path
+        /*) : ;;
         *) HOOKS_DIR="$TARGET/$HOOKS_DIR" ;;
     esac
 else
     GIT_DIR=$(git -C "$TARGET" rev-parse --git-dir)
     case "$GIT_DIR" in
-        /* | [A-Za-z]:*) : ;;  # POSIX-absolute or Windows drive-letter (C:/...) path
+        /*) : ;;
         *) GIT_DIR="$TARGET/$GIT_DIR" ;;
     esac
     HOOKS_DIR="$GIT_DIR/hooks"

--- a/scripts/lint-handoff.sh
+++ b/scripts/lint-handoff.sh
@@ -196,7 +196,7 @@ if [ -n "$EMAIL_MATCHES" ]; then
     while IFS= read -r match; do
         address="${match##*:}"
         allowed=0
-        while IFS=$'\t' read -r value owner expires reason; do
+        while IFS=$'\t' read -r value owner expires _; do
             [ -z "$value" ] && continue
             if [ "$address" = "$value" ]; then
                 echo -e "  ${GREEN}OK Allowed PII email '$address' via pii-allowlist.json (owner: $owner, expires: $expires).${NC}"

--- a/scripts/verify-hooks.sh
+++ b/scripts/verify-hooks.sh
@@ -1,0 +1,226 @@
+#!/usr/bin/env bash
+# verify-hooks.sh - Read-only verification of local AAHP git-hook coverage.
+#
+# Given a target repository checkout, this classifies each REQUIRED local hook
+# (from the coverage registry in docs/hook-coverage.md) as one of:
+#   INSTALLED - hook present and byte-identical to the canonical scripts/hooks/ source
+#   DRIFTED   - hook present but its content differs from canonical
+#   EXEMPT    - hook declared exempt for this repo in the registry
+#   UNKNOWN   - required hook not installed, or the repo has no registry contract
+#
+# It MODIFIES NOTHING: it never installs, copies, backs up, or edits a hook. To
+# install or repair hooks, use scripts/install-hooks.sh instead.
+#
+# Usage:
+#   verify-hooks.sh [target-repo-path] [--repo owner/name] [--registry FILE] [--quiet]
+#
+# Options:
+#   --repo owner/name   Registry key to look up. Default: derived from the
+#                       target's origin remote, falling back to the dir basename.
+#   --registry FILE     Coverage registry to read. Default: docs/hook-coverage.md
+#                       next to this script.
+#   --quiet             Suppress the banner and info lines; keep the per-hook
+#                       report and the RESULT line.
+#   --help, -h          Show this help.
+#
+# Exit codes:
+#   0 = every required hook is INSTALLED or EXEMPT
+#   1 = at least one required hook is DRIFTED or UNKNOWN (coverage gap)
+#   2 = usage error (bad option, not a git repo, registry missing)
+#
+# The drift comparison uses aahp_checksum (SHA-256, CR-stripped) so a hook
+# checksums identically on a CRLF (Windows) or LF (Linux) working tree.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=_aahp-lib.sh
+source "$SCRIPT_DIR/_aahp-lib.sh"
+
+CANON_HOOKS="$SCRIPT_DIR/hooks"
+DEFAULT_REGISTRY="$SCRIPT_DIR/../docs/hook-coverage.md"
+REGISTRY_BEGIN="<!-- BEGIN hook-coverage-registry -->"
+REGISTRY_END="<!-- END hook-coverage-registry -->"
+
+TARGET=""
+REPO_SLUG=""
+REGISTRY=""
+QUIET=false
+
+while [ $# -gt 0 ]; do
+    case "$1" in
+        --repo)     REPO_SLUG="$2"; shift 2 ;;
+        --registry) REGISTRY="$2"; shift 2 ;;
+        --quiet)    QUIET=true; shift ;;
+        --help|-h)
+            sed -n '2,32p' "$0" | sed 's/^# \{0,1\}//'
+            exit 0
+            ;;
+        --*)
+            echo "Unknown option: $1" >&2
+            echo "Usage: verify-hooks.sh [target-repo-path] [--repo owner/name] [--registry FILE] [--quiet]" >&2
+            exit 2
+            ;;
+        *)
+            if [ -z "$TARGET" ]; then
+                TARGET="$1"; shift
+            else
+                echo "Unexpected argument: $1" >&2
+                exit 2
+            fi
+            ;;
+    esac
+done
+
+TARGET="${TARGET:-$(cd "$SCRIPT_DIR/.." && pwd)}"
+REGISTRY="${REGISTRY:-$DEFAULT_REGISTRY}"
+
+info() { [ "$QUIET" = true ] || echo "$@"; }
+
+# --- Validate inputs ---------------------------------------------------------
+if [ ! -f "$REGISTRY" ]; then
+    echo "Error: coverage registry not found: $REGISTRY" >&2
+    exit 2
+fi
+if ! git -C "$TARGET" rev-parse --git-dir >/dev/null 2>&1; then
+    echo "Error: $TARGET is not a git repository." >&2
+    exit 2
+fi
+
+# --- Resolve the repo slug ---------------------------------------------------
+if [ -z "$REPO_SLUG" ]; then
+    ORIGIN_URL="$(git -C "$TARGET" remote get-url origin 2>/dev/null || true)"
+    if [ -n "$ORIGIN_URL" ]; then
+        REPO_SLUG="$(printf '%s' "$ORIGIN_URL" \
+            | sed -E 's#^[a-zA-Z]+://[^/]+/##; s#^git@[^:]+:##; s#^ssh://git@[^/]+/##; s#\.git$##')"
+    fi
+    if [ -z "$REPO_SLUG" ]; then
+        REPO_SLUG="$(basename "$(cd "$TARGET" && pwd)")"
+    fi
+fi
+
+# --- Look up the repo row in the registry ------------------------------------
+# Emit a TSV of every registry row, then select the one matching REPO_SLUG.
+ROW="$(awk -v b="$REGISTRY_BEGIN" -v e="$REGISTRY_END" '
+    index($0, b) { inblock = 1; next }
+    index($0, e) { inblock = 0 }
+    inblock && $0 ~ /^[[:space:]]*\|/ {
+        n = split($0, c, "|")
+        for (i = 1; i <= n; i++) { gsub(/^[ \t]+|[ \t]+$/, "", c[i]) }
+        repo = c[2]
+        if (repo == "" || tolower(repo) == "repo") next   # header / stray
+        if (repo ~ /^:?-+:?$/) next                        # separator row
+        printf "%s\t%s\t%s\t%s\t%s\n", repo, c[3], c[4], c[5], c[6]
+    }
+' "$REGISTRY" | awk -F'\t' -v r="$REPO_SLUG" '$1 == r { print; exit }')"
+
+info ""
+info "========================================="
+info "  AAHP hook coverage verify"
+info "========================================="
+info "  Target:   $TARGET"
+info "  Repo:     $REPO_SLUG"
+info "  Registry: $REGISTRY"
+
+if [ -z "$ROW" ]; then
+    echo "  UNKNOWN  repo '$REPO_SLUG' is not declared in the coverage registry."
+    echo "-----------------------------------------"
+    echo "  RESULT: FAIL - no coverage contract for '$REPO_SLUG' (1 unknown)."
+    exit 1
+fi
+
+IFS=$'\t' read -r R_REPO R_TYPE R_REQUIRED R_EXEMPT R_REASON <<< "$ROW"
+: "$R_REPO" "$R_REASON"   # referenced for clarity; not otherwise used
+info "  Type:     $R_TYPE"
+
+# --- Resolve the target's hooks directory (read-only) ------------------------
+HOOKS_DIR="$(git -C "$TARGET" config --get core.hooksPath 2>/dev/null || true)"
+if [ -n "$HOOKS_DIR" ]; then
+    case "$HOOKS_DIR" in
+        /*) : ;;
+        *)  HOOKS_DIR="$TARGET/$HOOKS_DIR" ;;
+    esac
+else
+    GIT_DIR="$(git -C "$TARGET" rev-parse --git-dir)"
+    case "$GIT_DIR" in
+        /*) : ;;
+        *)  GIT_DIR="$TARGET/$GIT_DIR" ;;
+    esac
+    HOOKS_DIR="$GIT_DIR/hooks"
+fi
+info "  Hooks:    $HOOKS_DIR"
+info ""
+
+# --- Build the required-hook list --------------------------------------------
+REQUIRED_LIST=()
+if [ "$R_REQUIRED" != "none" ] && [ "$R_REQUIRED" != "-" ] && [ -n "$R_REQUIRED" ]; then
+    IFS=',' read -r -a REQUIRED_LIST <<< "$R_REQUIRED"
+fi
+
+hook_is_exempt() {
+    local h="$1" x
+    case "$R_EXEMPT" in
+        ""|"-") return 1 ;;
+        "all")  return 0 ;;
+    esac
+    local ex=()
+    IFS=',' read -r -a ex <<< "$R_EXEMPT"
+    for x in "${ex[@]}"; do
+        [ "$(printf '%s' "$x" | tr -d ' ')" = "$h" ] && return 0
+    done
+    return 1
+}
+
+n_installed=0
+n_drifted=0
+n_exempt=0
+n_unknown=0
+
+if [ "${#REQUIRED_LIST[@]}" -eq 0 ]; then
+    echo "  EXEMPT     (no local hooks required for this repo)"
+    n_exempt=$((n_exempt + 1))
+else
+    for raw in "${REQUIRED_LIST[@]}"; do
+        hook="$(printf '%s' "$raw" | tr -d ' ')"
+        [ -z "$hook" ] && continue
+
+        if hook_is_exempt "$hook"; then
+            echo "  EXEMPT     $hook (declared exempt: $R_REASON)"
+            n_exempt=$((n_exempt + 1))
+            continue
+        fi
+
+        canon="$CANON_HOOKS/$hook"
+        if [ ! -f "$canon" ]; then
+            echo "  UNKNOWN    $hook (no canonical reference in scripts/hooks/)"
+            n_unknown=$((n_unknown + 1))
+            continue
+        fi
+
+        dest="$HOOKS_DIR/$hook"
+        if [ ! -f "$dest" ]; then
+            echo "  UNKNOWN    $hook (required hook not installed)"
+            n_unknown=$((n_unknown + 1))
+            continue
+        fi
+
+        if [ "$(aahp_checksum "$dest")" = "$(aahp_checksum "$canon")" ]; then
+            echo "  INSTALLED  $hook"
+            n_installed=$((n_installed + 1))
+        else
+            echo "  DRIFTED    $hook (content differs from canonical scripts/hooks/$hook)"
+            n_drifted=$((n_drifted + 1))
+        fi
+    done
+fi
+
+info "-----------------------------------------"
+FAIL=$((n_drifted + n_unknown))
+SUMMARY="installed=$n_installed drifted=$n_drifted exempt=$n_exempt unknown=$n_unknown"
+if [ "$FAIL" -gt 0 ]; then
+    echo "  RESULT: FAIL - $SUMMARY"
+    exit 1
+else
+    echo "  RESULT: PASS - $SUMMARY"
+    exit 0
+fi


### PR DESCRIPTION
Fleet re-sync of the v3.5.0 canonical AAHP gate-script fixes from homeofe/improvements, plus the local hook tooling (AC#6 of homeofe/improvements#8).

## What changed
- `scripts/aahp-manifest.sh`: accept `--phase documentation` and preserve the optional `cross_repo_ref` field across manifest regeneration (v3.5.0).
- `scripts/lint-handoff.sh`: SC2034 unused-variable cleanup.
- `scripts/install-hooks.sh` + new `scripts/verify-hooks.sh`: refreshed local hook tooling (AC#6 bundle).
- `.ai/handoff/MANIFEST.json` regenerated by the consumer's own `aahp-manifest.sh` (tasks/next_task_id preserved).
- `.ai/handoff/STATUS.md`: dated handoff note.

## Preserved
- `AAHP_HANDOFF_FILES` (the one per-repo config line in `scripts/_aahp-lib.sh`) was preserved verbatim by the canonical `sync-gate-scripts.sh`; `_aahp-lib.sh` had no content change (line-endings only).
- `docs/hook-coverage.md` was intentionally NOT copied (framework-level estate inventory stays in homeofe/improvements).

## Gate
CI (aahp-verify) gates this PR. The consumer gate (`scripts/verify-handoff.sh . --level ci`) passed locally: Layers 1-3 OK, Layer 4 TRUST-TTL is a non-blocking WARN.

Do not merge automatically.